### PR TITLE
Swapping over the uuid library that's used after it was moved off of google code.

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -2,4 +2,4 @@ github.com/samuel/go-zookeeper/zk   ad552be7b78b762b4a8040ffc5518bdaf5b7225d
 github.com/Shopify/sarama           2ca3f4f9705b8391a9a1fe3e6ead0d57313108d9
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 code.google.com/p/gcfg              c2d3050044d05357eaf6c3547249ba57c5e235cb
-code.google.com/p/go-uuid           35bc42037350
+github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4

--- a/http_notifier.go
+++ b/http_notifier.go
@@ -12,7 +12,7 @@ package main
 
 import (
 	"bytes"
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"encoding/json"
 	log "github.com/cihub/seelog"
 	"net/http"


### PR DESCRIPTION
So after https://github.com/linkedin/Burrow/commit/3fb0fc34be9067843eee2318a0d6d062594598e9 (which was trying to fix #1) was pushed to fix one dependency problem I ran into another. This however wasn't allowing me to compile either, which was reporting the errors as shown below. I've [started an attempt to fix those](https://github.com/adamdecaf/Burrow/compare/fixing-compile...adamdecaf:fixing-kafka-client-compile) but it seems more involved than a simple fix.

```
~/src/go/src/github.com/linkedin/burrow $ go build
# github.com/linkedin/burrow
./kafka_client.go:52: undefined: sarama.NewClientConfig
./kafka_client.go:53: too many arguments in call to sarama.NewClient
./kafka_client.go:59: undefined: sarama.NewConsumerConfig
./kafka_client.go:60: cannot use sclient (type sarama.Client) as type []string in argument to sarama.NewConsumer
./kafka_client.go:69: cannot use sclient (type sarama.Client) as type *sarama.Client in field value:
	*sarama.Client is pointer to interface, not interface
./kafka_client.go:70: cannot use master (type sarama.Consumer) as type *sarama.Consumer in field value:
	*sarama.Consumer is pointer to interface, not interface
./kafka_client.go:148: pconsumer.AsyncClose undefined (type *sarama.PartitionConsumer has no field or method AsyncClose)
./kafka_client.go:185: client.client.Leader undefined (type *sarama.Client has no field or method Leader)
./kafka_client.go:194: undefined: sarama.LatestOffsets
./kafka_client.go:204: too many arguments in call to brokers[brokerID].GetAvailableOffsets
./kafka_client.go:204: too many errors
```