### PR TITLE
fix auth-type, now allowed to be blank, plain, or crammd5

### DIFF
--- a/config.go
+++ b/config.go
@@ -238,7 +238,7 @@ func ValidateConfig(app *ApplicationContext) error {
 			errs = append(errs, "Email template file does not exist")
 		}
 		if app.Config.Smtp.AuthType != "" {
-			if (app.Config.Smtp.AuthType != "plain") || (app.Config.Smtp.AuthType != "crammd5") {
+			if (app.Config.Smtp.AuthType != "plain") && (app.Config.Smtp.AuthType != "crammd5") {
 				errs = append(errs, "Email auth-type must be plain, crammd5, or blank")
 			}
 		}


### PR DESCRIPTION
Found this while attempting to use plain authentication to our SMTP server.