### PR TITLE
Added support for offsets from Kafka high-level consumer and Storm Kafka Spout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ burrow-src
 Burrow
 .*.swp
 !config
+.idea/
 log

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Burrow is a monitoring companion for [Apache Kafka](http://kafka.apache.org) tha
 ## Features
 * NO THRESHOLDS! Groups are evaluated over a sliding window.
 * Multiple Kafka Cluster support
-* Automatically monitors all consumers using Kafka-committed offsets
+* Automatically monitors all consumers using Kafka-committed offsets stored in either internal offsets topic or external Zookeeper
 * HTTP endpoint for consumer group status, as well as broker and consumer information
 * Configurable emailer for sending alerts for specific groups
 * Configurable HTTP client for sending alerts to another system for all groups

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Burrow is a monitoring companion for [Apache Kafka](http://kafka.apache.org) tha
 * HTTP endpoint for consumer group status, as well as broker and consumer information
 * Configurable emailer for sending alerts for specific groups
 * Configurable HTTP client for sending alerts to another system for all groups
+* Supports offsets managed by Storm Kafka Spout
 
 ## Getting Started
 ### Prerequisites

--- a/config.go
+++ b/config.go
@@ -44,9 +44,11 @@ type BurrowConfig struct {
 		ZookeeperPort int      `gcfg:"zookeeper-port"`
 		ZookeeperPath string   `gcfg:"zookeeper-path"`
 		OffsetsTopic  string   `gcfg:"offsets-topic"`
+		ZookeeperOffsetPaths	[]string	`gcfg:"zookeeper-offsets-path"`
 	}
 	Tickers struct {
 		BrokerOffsets int `gcfg:"broker-offsets"`
+		ZooKeeperOffsets int `gcfg:"zookeeper-offsets"`
 	}
 	Lagcheck struct {
 		Intervals   int   `gcfg:"intervals"`

--- a/config.go
+++ b/config.go
@@ -45,10 +45,12 @@ type BurrowConfig struct {
 		ZookeeperPath string   `gcfg:"zookeeper-path"`
 		OffsetsTopic  string   `gcfg:"offsets-topic"`
 		ZookeeperOffsetPaths	[]string	`gcfg:"zookeeper-offsets-path"`
+		StormOffsetPaths		[]string	`gcfg:"storm-offsets-path"`
 	}
 	Tickers struct {
 		BrokerOffsets int `gcfg:"broker-offsets"`
 		ZooKeeperOffsets int `gcfg:"zookeeper-offsets"`
+		StormOffsets int `gcfg:"storm-offsets"`
 	}
 	Lagcheck struct {
 		Intervals   int   `gcfg:"intervals"`

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -26,9 +26,12 @@ zookeeper=zkhost03.example.com
 zookeeper-port=2181
 zookeeper-path=/kafka-cluster
 offsets-topic=__consumer_offsets
+; uncomment the line below to monitor offsets stored in ZK by Kafka's high-level consumer
+; zookeeper-offsets-path=/kafka/cluster-production
 
 [tickers]
 broker-offsets=60
+; zookeeper-offsets=30
 
 [lagcheck]
 intervals=10

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -28,6 +28,8 @@ zookeeper-path=/kafka-cluster
 offsets-topic=__consumer_offsets
 ; uncomment the line below to monitor offsets stored in ZK by Kafka's high-level consumer
 ; zookeeper-offsets-path=/kafka/cluster-production
+; uncomment the line below to monitor offsets stored in ZK by Storm, the path should be pointed to SpoutConfig.zkRoot
+; storm-offsets-path=/kafka/cluster-production/stormconsumers
 
 [tickers]
 broker-offsets=60

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -34,6 +34,7 @@ offsets-topic=__consumer_offsets
 [tickers]
 broker-offsets=60
 ; zookeeper-offsets=30
+; storm-offsets=30
 
 [lagcheck]
 intervals=10

--- a/main.go
+++ b/main.go
@@ -184,6 +184,17 @@ func burrowMain() int {
 			defer zkOffsetClient.Stop()
 		}
 
+		stormOffsetPaths := appContext.Config.Kafka[cluster].StormOffsetPaths
+		if stormOffsetPaths != nil {
+			log.Infof("Starting Storm offset client for cluster %s. Offset paths is %s", cluster, stormOffsetPaths)
+			stormOffsetClient, err := NewStormOffsetClient(appContext, cluster)
+			if err != nil {
+				log.Criticalf("Cannot start Storm offset client for cluster %s: %v", cluster, err)
+				return 1
+			}
+			defer stormOffsetClient.Stop()
+		}
+
 		appContext.Clusters[cluster] = &KafkaCluster{Client: client, Zookeeper: zkconn}
 	}
 

--- a/main.go
+++ b/main.go
@@ -173,6 +173,17 @@ func burrowMain() int {
 		}
 		defer client.Stop()
 
+		zkOffsetPaths := appContext.Config.Kafka[cluster].ZookeeperOffsetPaths
+		if zkOffsetPaths != nil {
+			log.Infof("Starting Kafka offset client for cluster %s. Offset paths is %s", cluster, zkOffsetPaths)
+			zkOffsetClient, err := NewZooKeeperOffsetClient(appContext, cluster)
+			if err != nil {
+				log.Criticalf("Cannot start Kafka offset client for cluster %s: %v", cluster, err)
+				return 1
+			}
+			defer zkOffsetClient.Stop()
+		}
+
 		appContext.Clusters[cluster] = &KafkaCluster{Client: client, Zookeeper: zkconn}
 	}
 

--- a/storm_client.go
+++ b/storm_client.go
@@ -1,0 +1,189 @@
+/* Copyright 2015 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package main
+
+import (
+	"fmt"
+	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/cihub/seelog"
+	"regexp"
+	"strconv"
+	"time"
+	"errors"
+	"encoding/json"
+)
+
+type StormOffsetClient struct {
+	app             	*ApplicationContext
+	cluster            	string
+	conn    			*zk.Conn
+	stormOffsetTicker 	*time.Ticker
+}
+
+type Topology struct {
+	Id    			string
+	Name 			string
+}
+
+type Broker struct {
+	Host    		string
+	Port 			int
+}
+
+type SpoutState struct {
+	Topology    	Topology
+	Offset 			int
+	Partition 		int
+	Broker 			Broker
+	Topic 			string
+}
+
+// Monitor offsets stored inside ZK by Storm Kafka Spout.
+// Storm Kafka Spout stores offsets and other meta data in following ZK node
+//   /<SpoutConfig.zkRoot>/<SpoutConfig.id>/partition_<partitionId>
+// the zk node contains meta data, including the offset, encoded in json. Below is an example
+// {
+//    "broker": {
+//        "host": "kafka.sample.net",
+//        "port": 9092
+//    },
+//    "offset": 4285,
+//    "partition": 1,
+//    "topic": "testTopic",
+//    "topology": {
+//        "id": "fce905ff-25e0 -409e-bc3a-d855f 787d13b",
+//        "name": "Test Topology"
+//    }
+//  }
+func NewStormOffsetClient(app *ApplicationContext, cluster string) (*StormOffsetClient, error) {
+	zkhosts := make([]string, len(app.Config.Kafka[cluster].Zookeepers))
+	for i, host := range app.Config.Kafka[cluster].Zookeepers {
+		zkhosts[i] = fmt.Sprintf("%s:%v", host, app.Config.Kafka[cluster].ZookeeperPort)
+	}
+	zkconn, _, err := zk.Connect(zkhosts, time.Duration(app.Config.Zookeeper.Timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &StormOffsetClient{
+		app:     app,
+		cluster: cluster,
+		conn:    zkconn,
+	}
+
+	// Now get the first set of offsets and start a goroutine to continually check them
+	client.getOffsets(client.app.Config.Kafka[cluster].StormOffsetPaths)
+	client.stormOffsetTicker = time.NewTicker(time.Duration(client.app.Config.Tickers.StormOffsets) * time.Second)
+	go func() {
+		for _ = range client.stormOffsetTicker.C {
+			client.getOffsets(client.app.Config.Kafka[cluster].StormOffsetPaths)
+		}
+	}()
+
+	return client, nil
+}
+
+func parsePartitionId(partitionStr string)(int, error) {
+	re := regexp.MustCompile(`^partition_([0-9]+)$`)
+	if parsed := re.FindStringSubmatch(partitionStr); len(parsed) == 2 {
+		return strconv.Atoi(parsed[1])
+	} else {
+		return -1, errors.New("Invalid partition id: " + partitionStr)
+	}
+}
+
+func parseStormSpoutStateJson(stateStr string)(int, string, error) {
+	stateJson := new(SpoutState)
+	if err := json.Unmarshal([]byte(stateStr), &stateJson); err == nil {
+		log.Debugf("Parsed storm state [%s] to structure [%v]", stateStr, stateJson)
+		return stateJson.Offset, stateJson.Topic, nil
+	} else {
+		return -1, "", err
+	}
+}
+
+func (stormOffsetClient *StormOffsetClient) getOffsets(paths []string) {
+	log.Debugf("Start to refresh Storm offsets stored in paths: %s", paths)
+
+	for _, path := range paths {
+		kafkaSpouts, _, err := stormOffsetClient.conn.Children(path)
+		switch {
+		case err == nil:
+			for _, kafkaSpout := range kafkaSpouts {
+				go stormOffsetClient.getOffsetsForKafkaSpout(kafkaSpout, path + "/" + kafkaSpout)
+			}
+
+		case err == zk.ErrNoNode:
+			// don't tolerate mis-configuration, let's bail out
+			panic("Failed to fetch spouts in ZK path: " + path)
+
+		default:
+			// if we cannot even read the top level directory to get the list of all spouts, let's bail out
+			panic(err)
+		}
+	}
+}
+
+func (stormOffsetClient *StormOffsetClient) getOffsetsForKafkaSpout(kafkaSpout string, kafkaSpoutPath string) {
+
+	partition_ids, _, err := stormOffsetClient.conn.Children(kafkaSpoutPath)
+	switch {
+	case err == nil:
+		for _, partition_id := range partition_ids {
+			partition, errConversion := parsePartitionId(partition_id)
+			switch {
+			case errConversion == nil:
+				stormOffsetClient.getOffsetsForPartition(kafkaSpout, partition, kafkaSpoutPath + "/" + partition_id)
+
+			default:
+				log.Errorf("Something is very wrong! The partition id %s in storm spout %s in ZK path %s should be a number",
+					partition_id, kafkaSpout, kafkaSpoutPath)
+			}
+		}
+
+	default:
+		log.Warnf("Failed to read partitions for kafka spout %s in ZK path %s. Error: %v", kafkaSpout, kafkaSpoutPath, err)
+	}
+}
+
+func (stormOffsetClient *StormOffsetClient) getOffsetsForPartition(kafkaSpout string, partition int, partitionPath string) {
+	zkNodeStat := &zk.Stat {}
+
+	stateStr, zkNodeStat, err := stormOffsetClient.conn.Get(partitionPath)
+	switch {
+	case err == nil:
+		offset, topic, errConversion := parseStormSpoutStateJson(string(stateStr))
+		switch {
+		case errConversion == nil:
+			log.Debugf("About to sync Storm offset: [%s,%s,%v]::[%v,%v]\n", kafkaSpout, topic, partition, offset, zkNodeStat.Mtime)
+			partitionOffset := &PartitionOffset{
+				Cluster:   stormOffsetClient.cluster,
+				Topic:     topic,
+				Partition: int32(partition),
+				Group:     kafkaSpout,
+				Timestamp: int64(zkNodeStat.Mtime), // note: this is millis
+				Offset:    int64(offset),
+			}
+			timeoutSendOffset(stormOffsetClient.app.Storage.offsetChannel, partitionOffset, 1)
+
+		default:
+			log.Errorf("Something is very wrong! Cannot parse state json for partition %v in storm spout %s in ZK path %s: %s. Error: %v",
+				partition, kafkaSpout, partitionPath, stateStr, errConversion)
+		}
+
+	default:
+		log.Warnf("Failed to read data for partition %v in kafka spout %s in ZK path %s. Error: %v", partition, kafkaSpout, partitionPath, err)
+	}
+}
+
+func (stormOffsetClient *StormOffsetClient) Stop() {
+	stormOffsetClient.conn.Close()
+}

--- a/zookeeper_client.go
+++ b/zookeeper_client.go
@@ -1,0 +1,173 @@
+/* Copyright 2015 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package main
+
+import (
+	"fmt"
+	"github.com/samuel/go-zookeeper/zk"
+	log "github.com/cihub/seelog"
+	"strconv"
+	"time"
+)
+
+
+type ZooKeeperOffsetClient struct {
+	app             	*ApplicationContext
+	cluster            	string
+	conn    			*zk.Conn
+	zkOffsetTicker 		*time.Ticker
+	blacklistedConsumerGroups []string
+}
+
+// Monitor offsets stored inside ZK by Kafka High-Level Consumer.
+// The offsets are organized in following structure (from https://cwiki.apache.org/confluence/display/KAFKA/Kafka+data+structures+in+Zookeeper)
+//   /consumers/[groupId]/offsets/[topic]/[partitionId] -> long (offset)
+func NewZooKeeperOffsetClient(app *ApplicationContext, cluster string) (*ZooKeeperOffsetClient, error) {
+	zkhosts := make([]string, len(app.Config.Kafka[cluster].Zookeepers))
+	for i, host := range app.Config.Kafka[cluster].Zookeepers {
+		zkhosts[i] = fmt.Sprintf("%s:%v", host, app.Config.Kafka[cluster].ZookeeperPort)
+	}
+	zkconn, _, err := zk.Connect(zkhosts, time.Duration(app.Config.Zookeeper.Timeout)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &ZooKeeperOffsetClient{
+		app:     app,
+		cluster: cluster,
+		conn:    zkconn,
+	}
+
+	// Now get the first set of offsets and start a goroutine to continually check them
+	client.getOffsets(client.app.Config.Kafka[cluster].ZookeeperOffsetPaths)
+	client.zkOffsetTicker = time.NewTicker(time.Duration(client.app.Config.Tickers.ZooKeeperOffsets) * time.Second)
+	go func() {
+		for _ = range client.zkOffsetTicker.C {
+			client.getOffsets(client.app.Config.Kafka[cluster].ZookeeperOffsetPaths)
+		}
+	}()
+
+	return client, nil
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) isConsumerGroupBlacklisted(consumerGroup string)(bool) {
+	for _, blacklisted := range zkOffsetClient.blacklistedConsumerGroups {
+		if (blacklisted == consumerGroup) {
+			return true
+		}
+	}
+	return false
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) getOffsets(paths []string) {
+	log.Debugf("Start to refresh ZK based offsets stored in Kafka base paths: %s", paths)
+
+	for _, path := range paths {
+		consumerGroupPath := path + "/consumers"
+		consumerGroups, _, err := zkOffsetClient.conn.Children(consumerGroupPath)
+
+		switch {
+		case err == nil:
+			for _, consumerGroup := range consumerGroups {
+				if (!zkOffsetClient.isConsumerGroupBlacklisted(consumerGroup)) {
+					go zkOffsetClient.getOffsetsForConsumerGroup(consumerGroup, consumerGroupPath + "/" + consumerGroup)
+				} else {
+					log.Debugf("Skip this consumer group as it is blacklisted: " + consumerGroup)
+				}
+			}
+
+		case err == zk.ErrNoNode:
+			// don't tolerate mis-configuration, let's bail out
+			panic("Failed to read consumer groups in ZK path: " + consumerGroupPath)
+
+		default:
+			// if we cannot even read the top level directory to get the list of all consumer groups, let's bail out
+			panic(err)
+		}
+	}
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) getOffsetsForConsumerGroup(consumerGroup string, consumerGroupPath string) {
+	topicsPath := consumerGroupPath + "/offsets"
+
+	topics, _, err := zkOffsetClient.conn.Children(topicsPath)
+	switch {
+	case err == nil:
+		for _, topic := range topics {
+			go zkOffsetClient.getOffsetsForTopic(consumerGroup, topic, topicsPath + "/" + topic)
+		}
+
+	case err == zk.ErrNoNode:
+		// it is OK as the offsets may not be managed by ZK
+		zkOffsetClient.blacklistedConsumerGroups = append(zkOffsetClient.blacklistedConsumerGroups, consumerGroup)
+		log.Warnf("ZK path %s does not exist. Maybe this consumer group's offset is not managed by ZK, so we will blacklist it: %s",
+			topicsPath, consumerGroup)
+
+	default:
+		log.Warnf("Failed to read topics for consumer group %s in ZK path %s. Error: %s", consumerGroup, topicsPath, err)
+	}
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) getOffsetsForTopic(consumerGroup string, topic string, topicPath string) {
+
+	partitions, _, err := zkOffsetClient.conn.Children(topicPath)
+	switch {
+	case err == nil:
+		for _, partitionStr := range partitions {
+			partition, errConversion := strconv.Atoi(partitionStr)
+			switch {
+			case errConversion == nil:
+				go zkOffsetClient.getOffsetForPartition(consumerGroup, topic,  partition, topicPath + "/" + partitionStr)
+
+			default:
+				log.Errorf("Something is very wrong! The partition %s for topic %s in consumer group %s in ZK path %s should be a number",
+					partitionStr, topic, consumerGroup, topicPath)
+			}
+		}
+
+	default:
+		log.Warnf("Failed to read partitions for topic %s in consumer group %s in ZK path %s. Error: %s", topic, consumerGroup, topicPath, err)
+	}
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) getOffsetForPartition(consumerGroup string, topic string, partition int, partitionPath string) {
+	zkNodeStat := &zk.Stat {}
+
+	offsetStr, zkNodeStat, err := zkOffsetClient.conn.Get(partitionPath)
+	switch {
+	case err == nil:
+		offset, errConversion := strconv.Atoi(string(offsetStr))
+		switch {
+		case errConversion == nil:
+			log.Debugf("About to sync ZK based offset: [%s,%s,%v]::[%v,%v]\n", consumerGroup, topic, partition, offset, zkNodeStat.Mtime)
+			partitionOffset := &PartitionOffset{
+				Cluster:   zkOffsetClient.cluster,
+				Topic:     topic,
+				Partition: int32(partition),
+				Group:     consumerGroup,
+				Timestamp: int64(zkNodeStat.Mtime), // note: this is millis
+				Offset:    int64(offset),
+			}
+			timeoutSendOffset(zkOffsetClient.app.Storage.offsetChannel, partitionOffset, 1)
+
+		default:
+			log.Errorf("Something is very wrong! The offset %s for partition %s for topic %s in consumer group %s in ZK path %s should be a number",
+				offsetStr, partition, topic, consumerGroup, partitionPath)
+		}
+
+	default:
+		log.Warnf("Failed to read partition for partition %s of topic %s in consumer group %s in ZK path %s. Error: %s", partition, topic, consumerGroup, partitionPath, err)
+	}
+}
+
+func (zkOffsetClient *ZooKeeperOffsetClient) Stop() {
+	zkOffsetClient.conn.Close()
+}


### PR DESCRIPTION
Hi,

We have adopted this great tool in our team to monitor our production Kafka applications for a while.  As there are still applications implemented with Kafka high-level consumer and stores offsets in ZK, we added a new feature to support monitoring those offsets as well.  The change is completely backward compatible and is turned off if the ZK offset configuration is absent.  I hope this can benefit people that are in the same situation like us.

Regards,

Hang