### PR TITLE
Fix storm config handling

### DIFF
--- a/config.go
+++ b/config.go
@@ -436,39 +436,39 @@ func validateUrl(rawUrl string) bool {
 func checkHostlist(hosts []string, defaultPort int, appName string) string {
 	for i, host := range hosts {
 		hostparts := strings.Split(host, ":")
-    hostport := defaultPort
-    hostname := hostparts[0]
+		hostport := defaultPort
+		hostname := hostparts[0]
 
-    if len(hostparts) == 2 {
-      // Must be a hostname or IPv4 address with a port
-      var err error
-      hostport, err = strconv.Atoi(hostparts[1])
+		if len(hostparts) == 2 {
+			// Must be a hostname or IPv4 address with a port
+			var err error
+			hostport, err = strconv.Atoi(hostparts[1])
 			if (err != nil) || (hostport == 0) {
 				return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
 			}
-    }
+		}
 
-    if len(hostparts) > 2 {
-      // Must be an IPv6 address
-      // Try without popping off the last segment as a port number first
-      if validateIP(host) {
-        hostname = host
-      } else {
-        // The full host didn't validate as an IP, so let's pull off the last piece as a port number and try again
-        hostname = strings.Join(hostparts[:len(hostparts)-1], ":")
+		if len(hostparts) > 2 {
+			// Must be an IPv6 address
+			// Try without popping off the last segment as a port number first
+			if validateIP(host) {
+				hostname = host
+			} else {
+				// The full host didn't validate as an IP, so let's pull off the last piece as a port number and try again
+				hostname = strings.Join(hostparts[:len(hostparts)-1], ":")
 
-        hostport, err := strconv.Atoi(hostparts[len(hostparts)-1])
-			  if (err != nil) || (hostport == 0) {
-				  return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
-			  }
-      }
-    }
+				hostport, err := strconv.Atoi(hostparts[len(hostparts)-1])
+				if (err != nil) || (hostport == 0) {
+					return fmt.Sprintf("One or more %s hostnames have invalid port components", appName)
+				}
+			}
+		}
 
 		if !validateHostname(hostname) {
 			return fmt.Sprintf("One or more %s hostnames are invalid", appName)
 		}
 
-	  hosts[i] = fmt.Sprintf("[%s]:%v", hostname, hostport)
+		hosts[i] = fmt.Sprintf("[%s]:%v", hostname, hostport)
 	}
 
 	return ""

--- a/config.go
+++ b/config.go
@@ -210,7 +210,7 @@ func ValidateConfig(app *ApplicationContext) error {
 
 	// Storm Clusters
 	if len(app.Config.Storm) > 0 {
-		for cluster, cfg := range app.Config.Kafka {
+		for cluster, cfg := range app.Config.Storm {
 			if cfg.ZookeeperPort == 0 {
 				cfg.ZookeeperPort = 2181
 			}


### PR DESCRIPTION
I was running into some issues while configuring burrow to monitor the lag of some storm topologies.  The current code in config.go is looking at the kafka config stanzas rather than the storm stanzas.  The first commit in this pull request fixes that issue.

The second commit contains nothing other than changes introduced by 'go fmt' on the checkHostlist function in config.go.