### PR TITLE
Fix growing slices in maps

### DIFF
--- a/offsets_store.go
+++ b/offsets_store.go
@@ -221,6 +221,7 @@ func (storage *OffsetStorage) addBrokerOffset(offset *PartitionOffset) {
 		for i := len(topicList); i < offset.TopicPartitionCount; i++ {
 			topicList = append(topicList, nil)
 		}
+		clusterMap.broker[offset.Topic] = topicList
 	}
 
 	partitionEntry := topicList[offset.Partition]
@@ -295,6 +296,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *PartitionOffset) {
 		for i := len(consumerTopicMap); i < partitionCount; i++ {
 			consumerTopicMap = append(consumerTopicMap, nil)
 		}
+		consumerMap[offset.Topic] = consumerTopicMap
 	}
 
 	consumerPartitionRing := consumerTopicMap[offset.Partition]


### PR DESCRIPTION
Fix slice management were append() were performed on the function-local slice instead of the one stored in the map object.
We now update the slice stored in the map with the local copy.