### PR TITLE
Fix not found storm consumer groups when zookeeper-path=/

### DIFF
--- a/storm.go
+++ b/storm.go
@@ -107,9 +107,16 @@ func parseStormSpoutStateJson(stateStr string) (int, string, error) {
 	}
 }
 
-func (stormClient *StormClient) getOffsetsForConsumerGroup(consumerGroup string) {
+func (stormClient *StormClient) getConsumerGroupPath(consumerGroup string) string {
+	if "/" == stormClient.app.Config.Storm[stormClient.cluster].ZookeeperPath {
+		return "/" + consumerGroup
+	} else {
+		return stormClient.app.Config.Storm[stormClient.cluster].ZookeeperPath + "/" + consumerGroup
+	}
+}
 
-	consumerGroupPath := stormClient.app.Config.Storm[stormClient.cluster].ZookeeperPath + "/" + consumerGroup
+func (stormClient *StormClient) getOffsetsForConsumerGroup(consumerGroup string) {
+	consumerGroupPath := getConsumerGroupPath(consumerGroup)
 	partition_ids, _, err := stormClient.conn.Children(consumerGroupPath)
 	switch {
 	case err == nil:

--- a/storm.go
+++ b/storm.go
@@ -116,7 +116,7 @@ func (stormClient *StormClient) getConsumerGroupPath(consumerGroup string) strin
 }
 
 func (stormClient *StormClient) getOffsetsForConsumerGroup(consumerGroup string) {
-	consumerGroupPath := getConsumerGroupPath(consumerGroup)
+	consumerGroupPath := stormClient.getConsumerGroupPath(consumerGroup)
 	partition_ids, _, err := stormClient.conn.Children(consumerGroupPath)
 	switch {
 	case err == nil:


### PR DESCRIPTION
Burrow wasn't handling well the situation where storm consumer groups
were stored at zookeeper root path `zookeeper-path=/`. It was trying
to get consumer group metadata building zookeeper path like this:
`//consumerGroupName` which was an invalid path. The fix handle this
situation by building the a path like: `/consumerGroupName` which is
valid.