### PR TITLE
Log an error message when we encounter trouble with getting leader info

### DIFF
--- a/kafka_client.go
+++ b/kafka_client.go
@@ -185,6 +185,7 @@ func (client *KafkaClient) getOffsets() error {
 			broker, err := client.client.Leader(topic, int32(i))
 			if err != nil {
 				client.topicMapLock.RUnlock()
+				log.Errorf("Topic leader error on %s:%v: %v", topic, int32(i), err)
 				return err
 			}
 			if _, ok := requests[broker.ID()]; !ok {


### PR DESCRIPTION
Turns out Burrow doesn't do anything but silently fail if there's an error here. So as a first step, this PR at least logs the error. But in the same file on lines 104 and 108, we call `client.getOffsets()` and don't attempt at all to handle the error. Not sure we would want to panic and exit, but I'm not sure how else we would handle this error. Skip that topic and keep trying other topics, maybe?