### PR TITLE
Set Kafka refresh frequency parameter

### DIFF
--- a/config.go
+++ b/config.go
@@ -44,14 +44,15 @@ type BurrowConfig struct {
 		LockPath string   `gcfg:"lock-path"`
 	}
 	Kafka map[string]*struct {
-		Brokers       []string `gcfg:"broker"`
-		BrokerPort    int      `gcfg:"broker-port"`
-		Zookeepers    []string `gcfg:"zookeeper"`
-		ZookeeperPort int      `gcfg:"zookeeper-port"`
-		ZookeeperPath string   `gcfg:"zookeeper-path"`
-		OffsetsTopic  string   `gcfg:"offsets-topic"`
-		ZKOffsets     bool     `gcfg:"zookeeper-offsets"`
-		Clientprofile string   `gcfg:"client-profile"`
+		Brokers           []string `gcfg:"broker"`
+		BrokerPort        int      `gcfg:"broker-port"`
+		Zookeepers        []string `gcfg:"zookeeper"`
+		ZookeeperPort     int      `gcfg:"zookeeper-port"`
+		ZookeeperPath     string   `gcfg:"zookeeper-path"`
+		OffsetsTopic      string   `gcfg:"offsets-topic"`
+		ZKOffsets         bool     `gcfg:"zookeeper-offsets"`
+		Clientprofile     string   `gcfg:"client-profile"`
+		RefreshFrequency  int      `gcfg:"refresh-frequency"`
 	}
 	Storm map[string]*struct {
 		Zookeepers    []string `gcfg:"zookeeper"`
@@ -247,6 +248,9 @@ func ValidateConfig(app *ApplicationContext) error {
 			if _, ok := app.Config.Clientprofile[cfg.Clientprofile]; !ok {
 				errs = append(errs, fmt.Sprintf("Kafka client profile is not defined for cluster %s", cluster))
 			}
+		}
+		if cfg.RefreshFrequency == 0 {
+			cfg.RefreshFrequency = 600
 		}
 	}
 

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -26,6 +26,7 @@ zookeeper=zkhost03.example.com
 zookeeper-port=2181
 zookeeper-path=/kafka-cluster
 offsets-topic=__consumer_offsets
+refresh-frequency=600
 
 [storm "local"]
 zookeeper=zkhost01.example.com

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -45,6 +45,7 @@ type BrokerTopicRequest struct {
 func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, error) {
 	// Set up sarama config from profile
 	clientConfig := sarama.NewConfig()
+	clientConfig.Metadata.RefreshFrequency = time.Duration(app.Config.Kafka[cluster].RefreshFrequency) * time.Second
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
 	clientConfig.Net.TLS.Enable = profile.TLS


### PR DESCRIPTION
# Goal

In our use case we need Burrow to rapidly discover newly created topic. The default 10 minutes is too long for us.
# Feature

This feature give the ability to set the Kafka _refreshFrequency_ parameter. 
By default it is 10 minutes, the value can be changed from Burrow configuration file.

Thank you,
