### PR TITLE
State consumer is stopped only when offsets haven't been committed in a while and consumer is lagging

### DIFF
--- a/offsets_store.go
+++ b/offsets_store.go
@@ -514,8 +514,8 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 			}
 			status.TotalLag += uint64(lastOffset.Lag)
 
-			// Rule 4 - Offsets haven't been committed in a while
-			if ((time.Now().Unix() * 1000) - lastOffset.Timestamp) > (lastOffset.Timestamp - firstOffset.Timestamp) {
+			// Rule 4 - Offsets haven't been committed in a while and consumer is lagging
+			if (((time.Now().Unix() * 1000) - lastOffset.Timestamp) > (lastOffset.Timestamp - firstOffset.Timestamp)) && (lastOffset.Lag > 0) {
 				status.Status = StatusError
 				thispart.Status = StatusStop
 				status.Partitions = append(status.Partitions, thispart)


### PR DESCRIPTION
Hello,
We are experiencing some problems with Burrow when topic partitions don't receive new messages in a while. In that case, Burrow states the consumer is stopped because no new offset is being committed, although the consumer is up to date.

Reading the documentation at https://github.com/linkedin/Burrow/wiki/Consumer-Lag-Evaluation-Rules , we expected its status to be ok, according to the last sentence of the Rule 4: "However, if the consumer offset and the current broker offset for the partition are equal, the partition is not considered to be in error."