### PR TITLE
Allow periods in the name of a topic

### DIFF
--- a/config.go
+++ b/config.go
@@ -458,7 +458,7 @@ func validateZookeeperPath(path string) bool {
 }
 
 func validateTopic(topic string) bool {
-	matches, _ := regexp.MatchString(`^[a-zA-Z0-9_\-]+$`, topic)
+	matches, _ := regexp.MatchString(`^[a-zA-Z0-9_\.-]+$`, topic)
 	return matches
 }
 


### PR DESCRIPTION
Periods are allowed to be part of the name of a topic according to Kafka documentation.