### PR TITLE
fix docker build => burrow to Burrow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add --update bash curl git && rm -rf /var/cache/apk/*
 RUN curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm && \
   chmod +x gpm && mv gpm /usr/local/bin
 
-ADD . $GOPATH/src/github.com/linkedin/burrow
-RUN cd $GOPATH/src/github.com/linkedin/burrow && gpm install && go install
+ADD . $GOPATH/src/github.com/linkedin/Burrow
+RUN cd $GOPATH/src/github.com/linkedin/Burrow && gpm install && go install && mv $GOPATH/bin/Burrow $GOPATH/bin/burrow
 
 ADD docker-config /etc/burrow
 


### PR DESCRIPTION
currently, `docker build .` fails.
I fixed `ADD` path `b`urrow => `B`urrow

<details>
<summary>build log before</summary>
```bash
~ghh/linkedin/Burrow(master) $ docker build .
Sending build context to Docker daemon 13.82 MB
Step 1 : FROM golang:alpine
 ---> 6b317e0ae72c
Step 2 : MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 ---> Using cache
 ---> 72cfdfe7c00d
Step 3 : RUN apk add --update bash curl git && rm -rf /var/cache/apk/*
 ---> Using cache
 ---> 2fdee1e82f62
Step 4 : RUN curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm &&   chmod +x gpm && mv gpm /usr/local/bin
 ---> Using cache
 ---> fe5492556bc9
Step 5 : ADD . $GOPATH/src/github.com/linkedin/burrow
 ---> 621af4c17f2a
Removing intermediate container 683afb3b33f6
Step 6 : RUN cd $GOPATH/src/github.com/linkedin/burrow && gpm install && go install
 ---> Running in 187997d855bb
>> Getting package github.com/pborman/uuid
>> Getting package gopkg.in/gcfg.v1
>> Getting package github.com/cihub/seelog
>> Getting package github.com/Shopify/sarama
>> Getting package github.com/samuel/go-zookeeper/zk
>> Setting github.com/pborman/uuid to version ca53cad383cad2479bbba7f7a1a05797ec1386e4
>> Setting github.com/cihub/seelog to version 92dc4b8b540607b8187cc2f95cac200211dcd745
>> Setting github.com/samuel/go-zookeeper/zk to version ad552be7b78b762b4a8040ffc5518bdaf5b7225d
>> Setting gopkg.in/gcfg.v1 to version 0ef1a8547f99b94fac9af5377dd72febba18f37c
>> Setting github.com/Shopify/sarama to version 4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
>> Building package github.com/samuel/go-zookeeper/zk
>> Building package github.com/Shopify/sarama
>> Building package github.com/cihub/seelog
>> Building package gopkg.in/gcfg.v1
>> Building package github.com/pborman/uuid
>> All Done
notify_center.go:15:2: cannot find package "github.com/linkedin/Burrow/notifier" in any of:
	/usr/local/go/src/github.com/linkedin/Burrow/notifier (from $GOROOT)
	/go/src/github.com/linkedin/Burrow/notifier (from $GOPATH)
debug.go:15:2: cannot find package "github.com/linkedin/Burrow/protocol" in any of:
	/usr/local/go/src/github.com/linkedin/Burrow/protocol (from $GOROOT)
	/go/src/github.com/linkedin/Burrow/protocol (from $GOPATH)
The command '/bin/sh -c cd $GOPATH/src/github.com/linkedin/burrow && gpm install && go install' returned a non-zero code: 1
```
</details>

<details>
<summary>build log after</summary>
```bash
Sending build context to Docker daemon   960 kB
Step 1 : FROM golang:alpine
 ---> 6b317e0ae72c
Step 2 : MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 ---> Using cache
 ---> 72cfdfe7c00d
Step 3 : RUN apk add --update bash curl git && rm -rf /var/cache/apk/*
 ---> Using cache
 ---> 2fdee1e82f62
Step 4 : RUN curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm &&   chmod +x gpm && mv gpm /usr/local/bin
 ---> Using cache
 ---> fe5492556bc9
Step 5 : ADD . $GOPATH/src/github.com/linkedin/Burrow
 ---> 326f26106ed7
Removing intermediate container b601dfcf9f35
Step 6 : RUN cd $GOPATH/src/github.com/linkedin/Burrow && gpm install && go build -o burrow && mv burrow $GOPATH/bin/
 ---> Running in 44ddc0702589
>> Getting package github.com/samuel/go-zookeeper/zk
>> Getting package github.com/Shopify/sarama
>> Getting package github.com/pborman/uuid
>> Getting package github.com/cihub/seelog
>> Getting package gopkg.in/gcfg.v1
>> Setting gopkg.in/gcfg.v1 to version 0ef1a8547f99b94fac9af5377dd72febba18f37c
>> Setting github.com/pborman/uuid to version ca53cad383cad2479bbba7f7a1a05797ec1386e4
>> Setting github.com/cihub/seelog to version 92dc4b8b540607b8187cc2f95cac200211dcd745
>> Setting github.com/Shopify/sarama to version 4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
>> Setting github.com/samuel/go-zookeeper/zk to version ad552be7b78b762b4a8040ffc5518bdaf5b7225d
>> Building package github.com/samuel/go-zookeeper/zk
>> Building package github.com/Shopify/sarama
>> Building package github.com/cihub/seelog
>> Building package gopkg.in/gcfg.v1
>> Building package github.com/pborman/uuid
>> All Done
 ---> 02deaa26a2f3
Removing intermediate container 44ddc0702589
Step 7 : ADD docker-config /etc/burrow
 ---> 41919e302c69
Removing intermediate container 87d2d153c967
Step 8 : WORKDIR /var/tmp/burrow
 ---> Running in 02226876b1dd
 ---> 4741cd8ecfbf
Removing intermediate container 02226876b1dd
Step 9 : CMD /go/bin/burrow --config /etc/burrow/burrow.cfg
 ---> Running in cee1cf49ae5f
 ---> 94a03bb6260d
Removing intermediate container cee1cf49ae5f
Successfully built 94a03bb6260d
```
</details>