### PR TITLE
Fix emailnotifier section name regarding BurrowConfig struct

### DIFF
--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -51,7 +51,7 @@ port=25
 from=burrow-noreply@example.com
 template=config/default-email.tmpl
 
-[email "bofh@example.com"]
+[emailnotifier "bofh@example.com"]
 group=local,critical-consumer-group
 group=local,other-consumer-group
 interval=60


### PR DESCRIPTION
Error when running burrow with config`[email "foo@bar.com"]` instead of `[emailnotifier "foo@bar.com"]` :

```
Reading configuration from /etc/burrow/burrow.cfg
2016/08/09 12:45:34 Failed to parse gcfg data: invalid section: section "email"
```