### PR TITLE
Fix handling of Notify.Interval default

### DIFF
--- a/config.go
+++ b/config.go
@@ -328,6 +328,11 @@ func ValidateConfig(app *ApplicationContext) error {
 		}
 	}
 
+	// Notify
+	if app.Config.Notify.Interval == 0 {
+		app.Config.Notify.Interval = 10
+	}
+
 	// SMTP server config
 	if app.Config.Smtp.Server != "" {
 		if !validateHostname(app.Config.Smtp.Server) {
@@ -355,11 +360,6 @@ func ValidateConfig(app *ApplicationContext) error {
 			}
 		}
 		// Username and password are not validated - they're optional
-
-		// Notify
-		if app.Config.Notify.Interval == 0 {
-			app.Config.Notify.Interval = 10
-		}
 
 		// Email configs
 		for email, cfg := range app.Config.Emailnotifier {


### PR DESCRIPTION
When there are no SMTP settings and you use e.g. a Slack notifier
without this patch it results in the following panic:

```
panic: invalid argument to Int63n

goroutine 988 [running]:
panic(0x7c0880, 0xc420e64240)
	$GOROOT/src/runtime/panic.go:500 +0x1a1
math/rand.(*Rand).Int63n(0xc420076080, 0x0, 0x0)
	$GOROOT/src/math/rand/rand.go:82 +0x13e
math/rand.Int63n(0x0, 0x0)
	$GOROOT/src/math/rand/rand.go:237 +0x37
main.(*NotifyCenter).startConsumerGroupEvaluator(0xc420e1f020, 0xc420314750, 0x22, 0xc420112cb0, 0x4)
	$GOPATH/src/github.com/linkedin/burrow/notify_center.go:166 +0x40
created by main.(*NotifyCenter).refreshConsumerGroups
	$GOPATH/src/github.com/linkedin/burrow/notify_center.go:149 +0x775
```