### PR TITLE
Add option to listen on multiple HTTP addresses

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,6 +74,7 @@ type BurrowConfig struct {
 	Httpserver struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`
+		Listen []string `gcfg:"listen"`
 	}
 	Notify struct {
 		Interval int64 `gcfg:"interval"`
@@ -324,8 +325,16 @@ func ValidateConfig(app *ApplicationContext) error {
 
 	// HTTP Server
 	if app.Config.Httpserver.Enable {
-		if app.Config.Httpserver.Port == 0 {
-			errs = append(errs, "HTTP server port is not specified")
+		if len(app.Config.Httpserver.Listen) == 0 {
+			if app.Config.Httpserver.Port == 0 {
+				errs = append(errs, "HTTP server port is not specified")
+			}
+			listenPort := fmt.Sprintf(":%v", app.Config.Httpserver.Port)
+			app.Config.Httpserver.Listen = append(app.Config.Httpserver.Listen, listenPort)
+		} else {
+			if app.Config.Httpserver.Port != 0 {
+				errs = append(errs, "Either HTTP server port or listen can be specified, but not both")
+			}
 		}
 	}
 

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -45,6 +45,9 @@ expire-group=604800
 [httpserver]
 server=on
 port=8000
+; Alternatively, use listen (cannot be specified when port is)
+; listen=host:port
+; listen=host2:port2
 
 [smtp]
 server=mailserver.example.com


### PR DESCRIPTION
This also fixes error reporting in case the port is used by another
process.
