### PR TITLE
Adding graphite notifier

### DIFF
--- a/config.go
+++ b/config.go
@@ -119,6 +119,13 @@ type BurrowConfig struct {
 		Timeout   int      `gcfg:"timeout"`
 		Keepalive int      `gcfg:"keepalive"`
 	}
+	Graphitenotifier struct {
+		Enable bool    `gcfg:"enable"`
+		Addr string    `gcfg:"addr"`
+		Prefix string  `gcfg:"prefix"`
+		Threshold int  `gcfg:"threshold"`
+		Interval int64 `gcfg:"interval"`
+	}
 	Clientprofile map[string]*ClientProfile
 }
 

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -81,3 +81,10 @@ username=burrower
 interval=5
 timeout=5
 keepalive=30
+
+[graphitenotifier]
+enable=true
+addr=localhost:2003
+prefix=stats.kafka.consumer
+threshold=0
+interval=30

--- a/notifier/graphite_notifier.go
+++ b/notifier/graphite_notifier.go
@@ -1,0 +1,98 @@
+/* Copyright 2015 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package notifier
+
+import (
+	"net"
+	"time"
+
+	log "github.com/cihub/seelog"
+
+	"bufio"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// GraphiteNotifier sends lags to graphite server
+type GraphiteNotifier struct {
+	threshold     int
+	metrics       map[string]int64
+	metricsLocker sync.Mutex
+}
+
+// NewGraphiteNotifier initializes sending lag metrics to graphite server
+func NewGraphiteNotifier(addr string, prefix string, interval int64, threshold int) (*GraphiteNotifier, error) {
+	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	if err != nil {
+		log.Error("Error while resolving graphite address.")
+		return nil, err
+	}
+
+	notifier := &GraphiteNotifier{threshold, make(map[string]int64), sync.Mutex{}}
+
+	go func() {
+		for range time.Tick(time.Duration(interval) * time.Second) {
+			notifier.sendToGraphite(tcpAddr, prefix)
+		}
+	}()
+
+	return notifier, nil
+}
+
+// NotifierName returns graphite name
+func (g *GraphiteNotifier) NotifierName() string {
+	return "graphite-notify"
+}
+
+// Ignore verifies if message should be ignored
+func (g *GraphiteNotifier) Ignore(msg Message) bool {
+	return int(msg.Status) < g.threshold
+}
+
+// Notify updates lag metrics
+func (g *GraphiteNotifier) Notify(msg Message) error {
+	for _, p := range msg.Partitions {
+		metricName := partitionMetricName(msg.Cluster, p.Topic, msg.Group, p.Partition)
+
+		g.metricsLocker.Lock()
+		g.metrics[metricName+".lag"] = p.End.Lag
+		g.metrics[metricName+".offset"] = p.End.Offset
+		g.metricsLocker.Unlock()
+	}
+	return nil
+}
+
+func (g *GraphiteNotifier) sendToGraphite(tcpAddr *net.TCPAddr, prefix string) {
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		log.Error("Error while creating connection to graphite.", err)
+		return
+	}
+	defer conn.Close()
+	writer := bufio.NewWriter(conn)
+
+	now := time.Now().Unix()
+	g.metricsLocker.Lock()
+	for name, value := range g.metrics {
+		fmt.Fprintf(writer, "%s.%s %d %d\n", prefix, name, value, now)
+	}
+	g.metricsLocker.Unlock()
+	writer.Flush()
+}
+
+func partitionMetricName(cluster string, topic string, group string, partition int32) string {
+	return fmt.Sprintf("%s.%s.%s.%d", escapeDots(cluster), escapeDots(topic), escapeDots(group), partition)
+}
+
+func escapeDots(toEscape string) string {
+	return strings.Replace(toEscape, ".", "_", -1)
+}

--- a/notifier/graphite_notifier_test.go
+++ b/notifier/graphite_notifier_test.go
@@ -1,0 +1,93 @@
+package notifier
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/linkedin/Burrow/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGraphiteNotification(t *testing.T) {
+	t.Parallel()
+
+	// given
+	addr, metrics, metricsWaiter := graphiteServer(t)
+	metricsWaiter.Add(1)
+
+	notifier, _ := NewGraphiteNotifier(addr.String(), "stats", 10, 0)
+
+	partitionsCount := 2
+	partitions := make([]*protocol.PartitionStatus, partitionsCount)
+	for i := 0; i < partitionsCount; i++ {
+		partitions[i] = &protocol.PartitionStatus{
+			Topic:     "kafka.topic",
+			Partition: int32(i),
+			Status:    protocol.StatusOK,
+			End:       protocol.ConsumerOffset{100, 1234, 20, false},
+		}
+	}
+	msg := Message{Cluster: "cluster", Group: "consumer.group", Status: protocol.StatusOK, Partitions: partitions}
+
+	// when
+	notifier.Notify(msg)
+	notifier.sendToGraphite(addr, "stats")
+
+	// then
+	metricsWaiter.Wait()
+	for i := 0; i < partitionsCount; i++ {
+		assert.Equal(t, int64(20), metrics[fmt.Sprintf("stats.cluster.kafka_topic.consumer_group.%d.lag", i)])
+		assert.Equal(t, int64(100), metrics[fmt.Sprintf("stats.cluster.kafka_topic.consumer_group.%d.offset", i)])
+	}
+}
+
+func TestIgnoreThreshold(t *testing.T) {
+	t.Parallel()
+
+	// when && then
+	assert.False(t, (&GraphiteNotifier{int(protocol.StatusNotFound), nil, sync.Mutex{}}).Ignore(Message{Status: protocol.StatusNotFound}))
+	assert.True(t, (&GraphiteNotifier{int(protocol.StatusOK), nil, sync.Mutex{}}).Ignore(Message{Status: protocol.StatusNotFound}))
+}
+
+func graphiteServer(t *testing.T) (*net.TCPAddr, map[string]int64, *sync.WaitGroup) {
+	metrics := make(map[string]int64)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal("Error while listening on localhost", err)
+	}
+
+	var waiter sync.WaitGroup
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				t.Fatal("Error while accepting connection", err)
+			}
+
+			r := bufio.NewReader(conn)
+			line, err := r.ReadString('\n')
+
+			for err == nil {
+				parts := strings.Split(line, " ")
+				i, _ := strconv.ParseInt(parts[1], 10, 64)
+
+				metrics[parts[0]] = metrics[parts[0]] + i
+				line, err = r.ReadString('\n')
+			}
+			waiter.Done()
+			conn.Close()
+		}
+	}()
+
+	addr, err := net.ResolveTCPAddr("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal("Error while resolving address", err)
+	}
+	return addr, metrics, &waiter
+}

--- a/notify_center.go
+++ b/notify_center.go
@@ -53,6 +53,11 @@ func LoadNotifiers(app *ApplicationContext) error {
 			notifiers = append(notifiers, slackNotifier)
 		}
 	}
+	if app.Config.Graphitenotifier.Enable {
+		if graphiteNotifier, err := NewGraphiteNotifier(app); err == nil {
+			notifiers = append(notifiers, graphiteNotifier)
+		}
+	}
 
 	nc := &NotifyCenter{
 		app:            app,
@@ -176,7 +181,7 @@ func (nc *NotifyCenter) startConsumerGroupEvaluator(group string, cluster string
 		nc.groupLock.RUnlock()
 
 		// Send requests for group status - responses are handled by the main loop (for now)
-		storageRequest := &RequestConsumerStatus{Result: nc.resultsChannel, Cluster: cluster, Group: group}
+		storageRequest := &RequestConsumerStatus{Result: nc.resultsChannel, Cluster: cluster, Group: group, Showall: true}
 		nc.app.Storage.requestChannel <- storageRequest
 
 		// Sleep for the check interval
@@ -259,4 +264,15 @@ func NewSlackNotifier(app *ApplicationContext) (*notifier.SlackNotifier, error) 
 			},
 		},
 	}, nil
+}
+
+func NewGraphiteNotifier(app *ApplicationContext) (*notifier.GraphiteNotifier, error) {
+	log.Info("Start Graphite Notify")
+
+	return notifier.NewGraphiteNotifier(
+		app.Config.Graphitenotifier.Addr,
+		app.Config.Graphitenotifier.Prefix,
+		app.Config.Graphitenotifier.Interval,
+		app.Config.Graphitenotifier.Threshold,
+	)
 }


### PR DESCRIPTION
Introducing notifier which allows sending lag metrics to a graphite server. Lag metrics are send in the following naming convention:

`$prefix.$cluster.$topic.$consumersGroup.$partitionIndex.lag`

We are using this notifier for a few months on a production environment.

