### PR TITLE
Added New Relic Insights notifier

### DIFF
--- a/config.go
+++ b/config.go
@@ -119,6 +119,17 @@ type BurrowConfig struct {
 		Timeout   int      `gcfg:"timeout"`
 		Keepalive int      `gcfg:"keepalive"`
 	}
+	NewRelicInsightsNotifier struct {
+		Enable           bool     `gcfg:"enable"`
+		Url              string   `gcfg:"url"`
+		InsertKey        string   `gcfg:"insert-key"`
+		EventType        string   `gcfg:"event-type"`
+		SendPerPartition bool     `gcfg:"send-per-partition"`
+		Threshold        int      `gcfg:"threshold"`
+		Groups           []string `gcfg:"group"`
+		Timeout          int      `gcfg:"timeout"`
+		Keepalive        int      `gcfg:"keepalive"`
+	}
 	Clientprofile map[string]*ClientProfile
 }
 
@@ -447,6 +458,25 @@ func ValidateConfig(app *ApplicationContext) error {
 		}
 		if app.Config.Slacknotifier.IconEmoji == "" {
 			app.Config.Slacknotifier.IconEmoji = ":ghost:"
+		}
+	}
+
+	// New Relic Insights Notifier config
+	if app.Config.NewRelicInsightsNotifier.Url != "" {
+		if !validateUrl(app.Config.NewRelicInsightsNotifier.Url) {
+			errs = append(errs, "New Relic Insights notifier URL is invalid")
+		}
+		if app.Config.NewRelicInsightsNotifier.InsertKey == "" {
+			errs = append(errs, "insert-key is required to POST to New Relic Insights")
+		}
+		if app.Config.NewRelicInsightsNotifier.EventType == "" {
+			app.Config.NewRelicInsightsNotifier.EventType = "BurrowStatusReport"
+		}
+		if app.Config.NewRelicInsightsNotifier.Threshold == 0 {
+			app.Config.NewRelicInsightsNotifier.Threshold = 1
+		}
+		if (app.Config.NewRelicInsightsNotifier.Threshold < 1) || (app.Config.NewRelicInsightsNotifier.Threshold > 3) {
+			errs = append(errs, "New Relic Insights notifier threshold must be between 1 and 3")
 		}
 	}
 

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -81,3 +81,13 @@ username=burrower
 interval=5
 timeout=5
 keepalive=30
+
+[newrelicinsightsnotifier]
+enable=false
+url=https://insights-collector.newrelic.com/v1/accounts/accountid/events
+insert-key=xxxxxxxxxxx
+event-type=BurrowStatusReport
+send-per-partition=false
+threshold=1
+timeout=5
+keepalive=30

--- a/notifier/new_relic_insights_notifier.go
+++ b/notifier/new_relic_insights_notifier.go
@@ -1,0 +1,135 @@
+/* Copyright 2015 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package notifier
+
+import (
+	log "github.com/cihub/seelog"
+	"net/http"
+	"time"
+	"bytes"
+	"io/ioutil"
+	"fmt"
+	"encoding/json"
+	"errors"
+)
+
+type NewRelicInsightsNotifier struct {
+	Url              string
+	InsertKey        string
+	EventType        string
+	SendPerPartition bool
+	Threshold        int
+	Groups	         []string
+	HttpClient       *http.Client
+	notifyGroups     map[string]struct{}
+}
+
+type ConsumerInsightsEvent struct {
+	EventType string `json:"eventType"`
+	Timestamp int64  `json:"timestamp"`
+	Cluster   string `json:"cluster"`
+	Group     string `json:"group"`
+	Status    string `json:"status"`
+}
+
+type PartitionInsightsEvent struct {
+	EventType string `json:"eventType"`
+	Timestamp int64  `json:"timestamp"`
+	Cluster   string `json:"cluster"`
+	Group     string `json:"group"`
+	Topic     string `json:"topic"`
+	Partition int32  `json:"partition"`
+	Status    string `json:"status"`
+	Lag       int64  `json:"lag"`
+}
+
+
+func (notifier *NewRelicInsightsNotifier) NotifierName() string {
+	return "new-relic-insights-notify"
+}
+
+func (notifier *NewRelicInsightsNotifier) Ignore(msg Message) bool {
+	if notifier.notifyGroups == nil {
+		// put groups into map for easy lookup
+		notifier.notifyGroups = make(map[string]struct{})
+		for _, clusterGroup := range notifier.Groups {
+			notifier.notifyGroups[clusterGroup] = struct{}{}
+		}
+	}
+
+	clusterGroup := fmt.Sprintf("%s,%s", msg.Cluster, msg.Group)
+	_, isInGroupsMap := notifier.notifyGroups[clusterGroup]
+
+	// ignore if status is below threshold or consumer group wasn't specified in config
+	// if no groups were specified, default to notifying for any consumer group
+	notifyForGroup := isInGroupsMap || len(notifier.Groups) == 0
+	return int(msg.Status) < notifier.Threshold || !notifyForGroup
+}
+
+func (notifier *NewRelicInsightsNotifier) Notify(msg Message) error {
+	startTime := int64(time.Nanosecond) * time.Now().UnixNano() / int64(time.Millisecond)
+
+	var events []interface{}
+	if notifier.SendPerPartition {
+		for _, partition := range msg.Partitions {
+			events = append(events, PartitionInsightsEvent {
+				EventType: notifier.EventType,
+				Timestamp: startTime,
+				Cluster:   msg.Cluster,
+				Group:     msg.Group,
+				Topic:     partition.Topic,
+				Partition: partition.Partition,
+				Status:    partition.Status.String(),
+				Lag:       partition.End.Offset - partition.Start.Offset,
+			})
+		}
+	} else {
+		events = append(events, ConsumerInsightsEvent {
+			EventType: notifier.EventType,
+			Timestamp: startTime,
+			Cluster:   msg.Cluster,
+			Group:     msg.Group,
+			Status:    msg.Status.String(),
+		})
+	}
+	return notifier.sendConsumerGroupStatusNotify(msg, events)
+}
+
+func (notifier *NewRelicInsightsNotifier) sendConsumerGroupStatusNotify(msg Message, events []interface{}) error {
+	data, err := json.Marshal(events)
+	if err != nil {
+		log.Errorf("Failed to assemble request body for New Relic Insights: %v", err)
+		return err
+	}
+
+	eventBytes := bytes.NewBuffer(data)
+	req, err := http.NewRequest("POST", notifier.Url, eventBytes)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Insert-Key", notifier.InsertKey)
+
+	if res, err := notifier.HttpClient.Do(req); err != nil {
+		log.Errorf("Unable to send data to New Relic Insights:%+v", err)
+		return err
+	} else {
+		defer res.Body.Close()
+		statusCode := res.StatusCode
+		if statusCode >= 200 && statusCode <= 299 {
+			log.Debugf("Sent New Relic Insights POST for group %s in cluster %s at severity %v",
+				msg.Group, msg.Cluster, msg.Status)
+			return nil
+		} else {
+			body, _ := ioutil.ReadAll(res.Body)
+			log.Errorf("Failed to send New Relic Insights POST for group %s in cluster %s. %s status returned: %s",
+				msg.Group, msg.Cluster, msg.Status, string(body))
+			return errors.New("POST to New Relic Insights failed")
+		}
+	}
+}

--- a/notifier/slack_notifier.go
+++ b/notifier/slack_notifier.go
@@ -78,6 +78,16 @@ func (slack *SlackNotifier) Notify(msg Message) error {
 	return nil
 }
 
+func getFailPartitions(partitions []*protocol.PartitionStatus) []*protocol.PartitionStatus {
+	var failPartitions []*protocol.PartitionStatus
+	for _, p := range partitions {
+		if p.Status != protocol.StatusOK {
+			failPartitions = append(failPartitions, p)
+		}
+	}
+	return failPartitions
+}
+
 func (slack *SlackNotifier) sendConsumerGroupStatusNotify() error {
 	msgs := make([]attachment, len(slack.Groups))
 	i := 0
@@ -96,14 +106,16 @@ func (slack *SlackNotifier) sendConsumerGroupStatusNotify() error {
 			color = "danger"
 		}
 
+		failPartitions := getFailPartitions(msg.Partitions)
+
 		title := "Burrow monitoring report"
 		fallback := fmt.Sprintf("%s is %s", msg.Group, msg.Status)
 		pretext := fmt.Sprintf("%s Group `%s` in Cluster `%s` is *%s*", emoji, msg.Group, msg.Cluster, msg.Status)
 
 		detailedBody := fmt.Sprintf("*Detail:* Total Partition = `%d` Fail Partition = `%d`\n",
-			msg.TotalPartitions, len(msg.Partitions))
+			msg.TotalPartitions, len(failPartitions))
 
-		for _, p := range msg.Partitions {
+		for _, p := range failPartitions {
 			detailedBody += fmt.Sprintf("*%s* *[%s:%d]* (%d, %d) -> (%d, %d)\n",
 				p.Status.String(), p.Topic, p.Partition, p.Start.Offset, p.Start.Lag, p.End.Offset, p.End.Lag)
 		}


### PR DESCRIPTION
Added a new notifier for posting consumer group status data to New Relic Insights.

Data can be sent one of two ways based on the send-per-partition config option:
- per consumer group (which simply sends the cluster, consumer group name, and the status)
- per partition (which sends a JSON object for each partition with the cluster, group, topic, partition number, status, and lag)

There are limitations on how things are sent to Insights because it requires that that request bodies are flat (no nested JSON objects), so this is what I came up with. Let me know if you have any ideas for making this better.