### PR TITLE
Enable the stdout/stderr logfile to be renamed and disabled. 

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type BurrowConfig struct {
 		ClientID       string `gcfg:"client-id"`
 		GroupBlacklist string `gcfg:"group-blacklist"`
 		GroupWhitelist string `gcfg:"group-whitelist"`
+		StdoutLogfile  string `gcfg:"stdout-logfile"`
 	}
 	Zookeeper struct {
 		Hosts    []string `gcfg:"hostname"`

--- a/docker-config/burrow.cfg
+++ b/docker-config/burrow.cfg
@@ -1,6 +1,7 @@
 [general]
 logconfig=/etc/burrow/logging.cfg
 group-blacklist=^(console-consumer-|python-kafka-consumer-).*$
+stdout-logfile=burrow.out
 
 [zookeeper]
 hostname=zookeeper

--- a/main.go
+++ b/main.go
@@ -60,8 +60,10 @@ func burrowMain() int {
 	createPidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 	defer removePidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 
-	// Set up stderr/stdout to go to a separate log file
-	openOutLog(appContext.Config.General.LogDir + "/burrow.out")
+	// Set up stderr/stdout to go to a separate log file, if enabled
+	if appContext.Config.General.StdoutLogfile != "" {
+		openOutLog(appContext.Config.General.LogDir + "/" + appContext.Config.General.StdoutLogfile)
+	}
 	fmt.Println("Started Burrow at", time.Now().Format("January 2, 2006 at 3:04pm (MST)"))
 
 	// If a logging config is specified, replace the existing loggers


### PR DESCRIPTION
Adds a stdout-logfile config key to the general block that, when set, redirects stdout/stderr to the specified file in the log directory.  Defaults added to the docker-config to match current behavior.

Resolves #57 