### PR TITLE
Log to stdout in the Docker container

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type BurrowConfig struct {
 		ClientID       string `gcfg:"client-id"`
 		GroupBlacklist string `gcfg:"group-blacklist"`
 		GroupWhitelist string `gcfg:"group-whitelist"`
+		StdoutLogfile  string `gcfg:"stdout-logfile"`
 	}
 	Zookeeper struct {
 		Hosts    []string `gcfg:"hostname"`

--- a/docker-config/burrow.cfg
+++ b/docker-config/burrow.cfg
@@ -1,7 +1,6 @@
 [general]
 logconfig=/etc/burrow/logging.cfg
 group-blacklist=^(console-consumer-|python-kafka-consumer-).*$
-stdout-logfile=burrow.out
 
 [zookeeper]
 hostname=zookeeper

--- a/docker-config/burrow.cfg
+++ b/docker-config/burrow.cfg
@@ -1,6 +1,7 @@
 [general]
 logconfig=/etc/burrow/logging.cfg
 group-blacklist=^(console-consumer-|python-kafka-consumer-).*$
+stdout-logfile=burrow.out
 
 [zookeeper]
 hostname=zookeeper

--- a/docker-config/logging.cfg
+++ b/docker-config/logging.cfg
@@ -1,6 +1,6 @@
 <seelog minlevel="debug">
   <outputs formatid="main">
-    <rollingfile type="date" filename="/var/tmp/burrow/burrow.log" datepattern="2006-01-02" maxrolls="7" />
+    <console />
   </outputs>
   <formats>
     <format id="main" format="%Date(2006-01-02 15:04:05) [%LEVEL] %Msg%n"/>

--- a/main.go
+++ b/main.go
@@ -60,8 +60,10 @@ func burrowMain() int {
 	createPidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 	defer removePidFile(appContext.Config.General.LogDir + "/" + appContext.Config.General.PIDFile)
 
-	// Set up stderr/stdout to go to a separate log file
-	openOutLog(appContext.Config.General.LogDir + "/burrow.out")
+	// Set up stderr/stdout to go to a separate log file, if enabled
+	if appContext.Config.General.StdoutLogfile != "" {
+		openOutLog(appContext.Config.General.LogDir + "/" + appContext.Config.General.StdoutLogfile)
+	}
 	fmt.Println("Started Burrow at", time.Now().Format("January 2, 2006 at 3:04pm (MST)"))
 
 	// If a logging config is specified, replace the existing loggers


### PR DESCRIPTION
This PR reconfigures the Docker config to log to stdout.  It reconfigures SeeLog to log to the console, and uses the changes from #151 to stop the app from grabbing stdout/stderr and sending them to burrow.out.  I believe this change will create the behavior most users will expect when running in a Docker container.

Note that this PR is simply for the config changes, but relies on the code changes in #151.