### PR TITLE
Support for multiple storms consumers off a single kafka cluster

### DIFF
--- a/config.go
+++ b/config.go
@@ -285,7 +285,7 @@ func ValidateConfig(app *ApplicationContext) error {
 				}
 			}
 			if len(cfg.ZookeeperPath) == 0 {
-                                errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
+				errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
 			} else {
 				for _, zkpath := range cfg.ZookeeperPath {
 					if zkpath == "" {

--- a/config.go
+++ b/config.go
@@ -57,7 +57,7 @@ type BurrowConfig struct {
 	Storm map[string]*struct {
 		Zookeepers    []string `gcfg:"zookeeper"`
 		ZookeeperPort int      `gcfg:"zookeeper-port"`
-		ZookeeperPath string   `gcfg:"zookeeper-path"`
+		ZookeeperPath []string `gcfg:"zookeeper-path"`
 	}
 	Tickers struct {
 		BrokerOffsets int `gcfg:"broker-offsets"`
@@ -284,11 +284,15 @@ func ValidateConfig(app *ApplicationContext) error {
 					errs = append(errs, hostlistError)
 				}
 			}
-			if cfg.ZookeeperPath == "" {
-				errs = append(errs, fmt.Sprintf("Zookeeper path is not specified for cluster %s", cluster))
+			if len(cfg.ZookeeperPath) == 0 {
+                                errs = append(errs, fmt.Sprintf("No Zookeeper paths specified for cluster %s", cluster))
 			} else {
-				if !validateZookeeperPath(cfg.ZookeeperPath) {
-					errs = append(errs, fmt.Sprintf("Zookeeper path is not valid for cluster %s", cluster))
+				for _, zkpath := range cfg.ZookeeperPath {
+					if zkpath == "" {
+						errs = append(errs, fmt.Sprintf("Zookeeper path is not specified for cluster %s", cluster))
+					} else if !validateZookeeperPath(zkpath) {
+						errs = append(errs, fmt.Sprintf("Zookeeper path is not valid for cluster %s", cluster))
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix for: https://github.com/linkedin/Burrow/issues/154

This will allow the burrow to monitor multiple storm consumers when they are reading from topics on the same kafka cluster, but committing their offsets to different locations.

Example of the new configuration this would support:
```
[storm "local"]
zookeeper=zkhost01.example.com
zookeeper=zkhost02.example.com
zookeeper=zkhost03.example.com
zookeeper-port=2181
zookeeper-path=/kafka-cluster/stormconsumers/primary
zookeeper-path=/kafka-cluster/stormconsumers/secondary
```

