### PR TITLE
Fix burrow name on readme command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ go install
 
 ### Running Burrow
 ```
-$ $GOPATH/bin/burrow --config path/to/burrow.cfg
+$ $GOPATH/bin/Burrow --config path/to/burrow.cfg
 ```
 
 ### Using Docker


### PR DESCRIPTION
After the `go install` command, the path to burrow will be `$GOPATH/bin/Burrow` and not `$GOPATH/bin/burrow`