### PR TITLE
Annotate partition status with ownership information

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,4 +1,4 @@
-github.com/samuel/go-zookeeper/zk   ad552be7b78b762b4a8040ffc5518bdaf5b7225d
+github.com/samuel/go-zookeeper/zk   1d7be4effb13d2d908342d349d71a284a7542693
 github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c

--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,5 @@
 github.com/samuel/go-zookeeper/zk   1d7be4effb13d2d908342d349d71a284a7542693
-github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
+github.com/Shopify/sarama           c01858abb625b73a3af51d0798e4ad42c8147093
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4

--- a/Godeps
+++ b/Godeps
@@ -3,3 +3,4 @@ github.com/Shopify/sarama           c01858abb625b73a3af51d0798e4ad42c8147093
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
+github.com/klauspost/crc32          1bab8b35b6bb565f92cbc97939610af9369f942a

--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"gopkg.in/gcfg.v1"
 	"log"
 	"net"
 	"net/url"
@@ -20,7 +21,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"gopkg.in/gcfg.v1"
+	"github.com/Shopify/sarama"
 )
 
 // Configuration definition
@@ -34,20 +35,20 @@ type ClientProfile struct {
 }
 type BurrowConfig struct {
 	General struct {
-		LogDir         string `gcfg:"logdir"`
-		LogConfig      string `gcfg:"logconfig"`
-		PIDFile        string `gcfg:"pidfile"`
-		ClientID       string `gcfg:"client-id"`
-		GroupBlacklist string `gcfg:"group-blacklist"`
-		GroupWhitelist string `gcfg:"group-whitelist"`
-		StdoutLogfile  string `gcfg:"stdout-logfile"`
-	}
+			LogDir         string `gcfg:"logdir"`
+			LogConfig      string `gcfg:"logconfig"`
+			PIDFile        string `gcfg:"pidfile"`
+			ClientID       string `gcfg:"client-id"`
+			GroupBlacklist string `gcfg:"group-blacklist"`
+			GroupWhitelist string `gcfg:"group-whitelist"`
+			StdoutLogfile  string `gcfg:"stdout-logfile"`
+		}
 	Zookeeper struct {
-		Hosts    []string `gcfg:"hostname"`
-		Port     int      `gcfg:"port"`
-		Timeout  int      `gcfg:"timeout"`
-		LockPath string   `gcfg:"lock-path"`
-	}
+			Hosts    []string `gcfg:"hostname"`
+			Port     int      `gcfg:"port"`
+			Timeout  int      `gcfg:"timeout"`
+			LockPath string   `gcfg:"lock-path"`
+		}
 	Kafka map[string]*struct {
 		Brokers       []string `gcfg:"broker"`
 		BrokerPort    int      `gcfg:"broker-port"`
@@ -65,34 +66,34 @@ type BurrowConfig struct {
 		ZookeeperPath []string `gcfg:"zookeeper-path"`
 	}
 	Tickers struct {
-		BrokerOffsets int `gcfg:"broker-offsets"`
-	}
+			BrokerOffsets int `gcfg:"broker-offsets"`
+		}
 	Lagcheck struct {
-		Intervals         int   `gcfg:"intervals"`
-		MinDistance       int64 `gcfg:"min-distance"`
-		ExpireGroup       int64 `gcfg:"expire-group"`
-		ZKCheck           int64 `gcfg:"zookeeper-interval"`
-		ZKGroupRefresh    int64 `gcfg:"zk-group-refresh"`
-		StormCheck        int64 `gcfg:"storm-interval"`
-		StormGroupRefresh int64 `gcfg:"storm-group-refresh"`
-	}
+			Intervals         int   `gcfg:"intervals"`
+			MinDistance       int64 `gcfg:"min-distance"`
+			ExpireGroup       int64 `gcfg:"expire-group"`
+			ZKCheck           int64 `gcfg:"zookeeper-interval"`
+			ZKGroupRefresh    int64 `gcfg:"zk-group-refresh"`
+			StormCheck        int64 `gcfg:"storm-interval"`
+			StormGroupRefresh int64 `gcfg:"storm-group-refresh"`
+		}
 	Httpserver struct {
-		Enable bool `gcfg:"server"`
-		Port   int  `gcfg:"port"`
-		Listen []string `gcfg:"listen"`
-	}
+			Enable bool `gcfg:"server"`
+			Port   int  `gcfg:"port"`
+			Listen []string `gcfg:"listen"`
+		}
 	Notify struct {
-		Interval int64 `gcfg:"interval"`
-	}
+			Interval int64 `gcfg:"interval"`
+		}
 	Smtp struct {
-		Server   string `gcfg:"server"`
-		Port     int    `gcfg:"port"`
-		AuthType string `gcfg:"auth-type"`
-		Username string `gcfg:"username"`
-		Password string `gcfg:"password"`
-		From     string `gcfg:"from"`
-		Template string `gcfg:"template"`
-	}
+			Server   string `gcfg:"server"`
+			Port     int    `gcfg:"port"`
+			AuthType string `gcfg:"auth-type"`
+			Username string `gcfg:"username"`
+			Password string `gcfg:"password"`
+			From     string `gcfg:"from"`
+			Template string `gcfg:"template"`
+		}
 	Emailnotifier map[string]*struct {
 		Enable    bool     `gcfg:"enable"`
 		Groups    []string `gcfg:"group"`
@@ -100,101 +101,57 @@ type BurrowConfig struct {
 		Threshold int      `gcfg:"threshold"`
 	}
 	Httpnotifier struct {
-		Enable         bool     `gcfg:"enable"`
-		Groups         []string `gcfg:"group"`
-		UrlOpen        string   `gcfg:"url"`
-		UrlClose       string   `gcfg:"url-delete"`
-		MethodOpen     string   `gcfg:"method"`
-		MethodClose    string   `gcfg:"method-delete"`
-		Interval       int64    `gcfg:"interval"`
-		Extras         []string `gcfg:"extra"`
-		TemplateOpen   string   `gcfg:"template-post"`
-		TemplateClose  string   `gcfg:"template-delete"`
-		SendClose      bool     `gcfg:"send-delete"`
-		PostThreshold  int      `gcfg:"post-threshold"`
-		Timeout        int      `gcfg:"timeout"`
-		Keepalive      int      `gcfg:"keepalive"`
-	}
+			Enable         bool     `gcfg:"enable"`
+			Groups         []string `gcfg:"group"`
+			UrlOpen        string   `gcfg:"url"`
+			UrlClose       string   `gcfg:"url-delete"`
+			MethodOpen     string   `gcfg:"method"`
+			MethodClose    string   `gcfg:"method-delete"`
+			Interval       int64    `gcfg:"interval"`
+			Extras         []string `gcfg:"extra"`
+			TemplateOpen   string   `gcfg:"template-post"`
+			TemplateClose  string   `gcfg:"template-delete"`
+			SendClose      bool     `gcfg:"send-delete"`
+			PostThreshold  int      `gcfg:"post-threshold"`
+			Timeout        int      `gcfg:"timeout"`
+			Keepalive      int      `gcfg:"keepalive"`
+		}
 	Slacknotifier struct {
-		Enable    bool     `gcfg:"enable"`
-		Groups    []string `gcfg:"group"`
-		Url       string   `gcfg:"url"`
-		Interval  int64    `gcfg:"interval"`
-		Channel   string   `gcfg:"channel"`
-		Username  string   `gcfg:"username"`
-		IconUrl   string   `gcfg:"icon-url"`
-		IconEmoji string   `gfcg:"icon-emoji"`
-		Threshold int      `gcfg:"threshold"`
-		Timeout   int      `gcfg:"timeout"`
-		Keepalive int      `gcfg:"keepalive"`
-	}
+			Enable    bool     `gcfg:"enable"`
+			Groups    []string `gcfg:"group"`
+			Url       string   `gcfg:"url"`
+			Interval  int64    `gcfg:"interval"`
+			Channel   string   `gcfg:"channel"`
+			Username  string   `gcfg:"username"`
+			IconUrl   string   `gcfg:"icon-url"`
+			IconEmoji string   `gfcg:"icon-emoji"`
+			Threshold int      `gcfg:"threshold"`
+			Timeout   int      `gcfg:"timeout"`
+			Keepalive int      `gcfg:"keepalive"`
+		}
 	Clientprofile map[string]*ClientProfile
 }
 
-// KafkaVersion helps to identify the version that the kafka brokers are running to check for protocol compatibility
-type KafkaVersion struct {
-	// it's a struct rather than just typing the array directly to make it opaque and stop people
-	// generating their own arbitrary versions
-	version [4]uint
-}
-
-func newKafkaVersion(major, minor, veryMinor, patch uint) KafkaVersion {
-	return KafkaVersion{
-		version: [4]uint{major, minor, veryMinor, patch},
-	}
-}
-
-// IsAtLeast return true if and only if the version it is called on is
-// greater than or equal to the version passed in:
-//    V1.IsAtLeast(V2) // false
-//    V2.IsAtLeast(V1) // true
-func (v KafkaVersion) IsAtLeast(other KafkaVersion) {
-	for i := range v.version {
-		if v.version[i] > other.version[i] {
-			return true
-		} else if v.version[i] < other.version[i] {
-			return false
-		}
-	}
-	return true
-}
-
-// Effective constants defining the supported kafka versions.
-var (
-	V0_8_2_0   = newKafkaVersion(0, 8, 2, 0)
-	V0_8_2_1   = newKafkaVersion(0, 8, 2, 1)
-	V0_8_2_2   = newKafkaVersion(0, 8, 2, 2)
-	V0_9_0_0   = newKafkaVersion(0, 9, 0, 0)
-	V0_9_0_1   = newKafkaVersion(0, 9, 0, 1)
-	V0_10_0_0  = newKafkaVersion(0, 10, 0, 0)
-	V0_10_0_1  = newKafkaVersion(0, 10, 0, 1)
-	V0_10_1_0  = newKafkaVersion(0, 10, 1, 0)
-	V0_10_2_0  = newKafkaVersion(0, 10, 2, 0)
-	minVersion = V0_8_2_0
-)
-
-func (cfg *BurrowConfig) ToKafkaVersion(cluster string) KafkaVersion {
+func (cfg *BurrowConfig) ToSaramaKafkaVersion(cluster string) sarama.KafkaVersion {
 	switch(cfg.Kafka[cluster].KafkaVersion) {
 	case "0.8.2.0":
-		return V0_8_2_0
+		return sarama.V0_8_2_0
 	case "0.8.2.1":
-		return V0_8_2_1
+		return sarama.V0_8_2_1
 	case "0.8.2.2":
-		return V0_8_2_2
+		return sarama.V0_8_2_2
 	case "0.9.0.0":
-		return V0_9_0_0
+		return sarama.V0_9_0_0
 	case "0.9.0.1":
-		return V0_9_0_1
+		return sarama.V0_9_0_1
 	case "0.10.0.0":
-		return V0_10_0_0
+		return sarama.V0_10_0_0
 	case "0.10.0.1":
-		return V0_10_0_1
+		return sarama.V0_10_0_1
 	case "0.10.1.0":
-		return V0_10_1_0
-	case "0.10.2.0":
-		return V0_10_2_0
+		return sarama.V0_10_1_0
 	default:
-		return minVersion
+		return sarama.V0_8_2_0
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"github.com/Shopify/sarama"
 	"code.google.com/p/gcfg"
 )
 

--- a/config.go
+++ b/config.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"code.google.com/p/gcfg"
+	"gopkg.in/gcfg.v1"
 )
 
 // Configuration definition

--- a/debug.go
+++ b/debug.go
@@ -12,7 +12,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 )
 
 func printConsumerGroupStatus(status *protocol.ConsumerGroupStatus) {

--- a/http_server.go
+++ b/http_server.go
@@ -12,7 +12,7 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"io"
 	"net/http"
 	"os"

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -311,12 +311,12 @@ func (client *KafkaClient) processConsumerOffsetsMessage(msg *sarama.ConsumerMes
 		}
 		topic, err = readString(buf)
 		if err != nil {
-			log.Warnf("Failed to decode %s:%v offset %v: topic", msg.Topic, msg.Partition, msg.Offset)
+			log.Warnf("Failed to decode %s:%v offset %v: topic; group %s", msg.Topic, msg.Partition, msg.Offset, group)
 			return
 		}
 		err = binary.Read(buf, binary.BigEndian, &partition)
 		if err != nil {
-			log.Warnf("Failed to decode %s:%v offset %v: partition", msg.Topic, msg.Partition, msg.Offset)
+			log.Warnf("Failed to decode %s:%v offset %v: partition; group %s topic %s", msg.Topic, msg.Partition, msg.Offset, group, topic)
 			return
 		}
 	case 2:
@@ -330,12 +330,12 @@ func (client *KafkaClient) processConsumerOffsetsMessage(msg *sarama.ConsumerMes
 	buf = bytes.NewBuffer(msg.Value)
 	err = binary.Read(buf, binary.BigEndian, &valver)
 	if (err != nil) || ((valver != 0) && (valver != 1)) {
-		log.Warnf("Failed to decode %s:%v offset %v: valver %v", msg.Topic, msg.Partition, msg.Offset, valver)
+		log.Warnf("Failed to decode %s:%v offset %v: valver %v; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition)
 		return
 	}
 	err = binary.Read(buf, binary.BigEndian, &offset)
 	if err != nil {
-		log.Warnf("Failed to decode %s:%v offset %v: offset", msg.Topic, msg.Partition, msg.Offset)
+		log.Warnf("Failed to decode %s:%v offset %v: offset; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition)
 		return
 	}
 	_, err = readString(buf)

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -14,12 +14,12 @@ import (
 	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"encoding/binary"
 	"errors"
 	"github.com/Shopify/sarama"
 	log "github.com/cihub/seelog"
 	"github.com/linkedin/Burrow/protocol"
+	"io/ioutil"
 	"sync"
 	"time"
 )
@@ -66,12 +66,12 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 		caCertPool.AppendCertsFromPEM(caCert)
 		clientConfig.Net.TLS.Config = &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			RootCAs: caCertPool,
+			RootCAs:      caCertPool,
 		}
 		clientConfig.Net.TLS.Config.BuildNameToCertificate()
 	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
-	clientConfig.Version = app.Config.ToSaramaKafkaVersion(cluster)
+	clientConfig.Version = app.Config.ToKafkaVersion(cluster)
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -141,7 +141,7 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	client.partitionConsumers = make([]sarama.PartitionConsumer, len(partitions))
 	log.Infof("Starting consumers for %v partitions of %s in cluster %s", len(partitions), client.app.Config.Kafka[client.cluster].OffsetsTopic, client.cluster)
 	for i, partition := range partitions {
-		pconsumer, err := client.masterConsumer.ConsumePartition(client.app.Config.Kafka[client.cluster].OffsetsTopic, partition, sarama.OffsetNewest)
+		pconsumer, err := client.masterConsumer.ConsumePartition(client.app.Config.Kafka[client.cluster].OffsetsTopic, partition, sarama.OffsetOldest)
 		if err != nil {
 			return nil, err
 		}

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -71,7 +71,7 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 		clientConfig.Net.TLS.Config.BuildNameToCertificate()
 	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
-	clientConfig.Version = app.Config.ToKafkaVersion(cluster)
+	clientConfig.Version = app.Config.ToSaramaKafkaVersion(cluster)
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -71,6 +71,7 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 		clientConfig.Net.TLS.Config.BuildNameToCertificate()
 	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
+	clientConfig.Version = app.Config.ToSaramaKafkaVersion(cluster)
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -330,12 +330,12 @@ func (client *KafkaClient) processConsumerOffsetsMessage(msg *sarama.ConsumerMes
 	buf = bytes.NewBuffer(msg.Value)
 	err = binary.Read(buf, binary.BigEndian, &valver)
 	if (err != nil) || ((valver != 0) && (valver != 1)) {
-		log.Warnf("Failed to decode %s:%v offset %v: valver %v; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition)
+		log.Warnf("Failed to decode %s:%v offset %v: valver %v; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition, err)
 		return
 	}
 	err = binary.Read(buf, binary.BigEndian, &offset)
 	if err != nil {
-		log.Warnf("Failed to decode %s:%v offset %v: offset; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition)
+		log.Warnf("Failed to decode %s:%v offset %v: offset; group %s topic %s partition %d; err=%s", msg.Topic, msg.Partition, msg.Offset, valver, group, topic, partition, err)
 		return
 	}
 	_, err = readString(buf)

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"github.com/Shopify/sarama"
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"io/ioutil"
 	"sync"
 	"time"

--- a/notifier/helpers.go
+++ b/notifier/helpers.go
@@ -12,7 +12,7 @@ package notifier
 
 import (
 	"encoding/json"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 )
 
 // Helper function for the templates to encode an object into a JSON string

--- a/notifier/http_notifier.go
+++ b/notifier/http_notifier.go
@@ -13,7 +13,7 @@ package notifier
 import (
 	"bytes"
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"github.com/pborman/uuid"
 	"io"
 	"io/ioutil"

--- a/notifier/http_notifier.go
+++ b/notifier/http_notifier.go
@@ -21,6 +21,7 @@ import (
 	"text/template"
 	"time"
 	"fmt"
+	"sync"
 )
 
 type HttpNotifier struct {
@@ -31,9 +32,11 @@ type HttpNotifier struct {
 	Extras             map[string]string
 	HttpClient         *http.Client
 	groupIds           map[string]map[string]Event
+	sync.Mutex
 }
 
 type HttpNotifierRequest struct {
+	sync.Mutex
 	Url string
 	TemplateFile string
 	Method string
@@ -50,6 +53,8 @@ func (notify *HttpNotifier) NotifierName() string {
 }
 
 func (notifier *HttpNotifier) Notify(msg Message) error {
+	notifier.Lock()
+	defer notifier.Unlock()
 	// Helper functions for templates
 	fmap := template.FuncMap{
 		"jsonencoder":     templateJsonEncoder,

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -11,7 +11,7 @@
 package notifier
 
 import (
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 )
 
 type Message protocol.ConsumerGroupStatus

--- a/notifier/slack_notifier.go
+++ b/notifier/slack_notifier.go
@@ -16,7 +16,7 @@ import (
 	"errors"
 	"fmt"
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"io/ioutil"
 	"net/http"
 	"time"

--- a/notify_center.go
+++ b/notify_center.go
@@ -12,8 +12,8 @@ package main
 
 import (
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/notifier"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/notifier"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"math/rand"
 	"net"
 	"net/http"

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -185,6 +185,7 @@ func (storage *OffsetStorage) addBrokerOffset(offset *protocol.PartitionOffset) 
 		partitionEntry.Timestamp = offset.Timestamp
 	}
 
+	clusterMap.broker[offset.Topic] = topicList
 	clusterMap.brokerLock.Unlock()
 }
 

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -433,7 +433,10 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 			// last offset timestamp is outside the MinDistance threshold
 			lastOffset := offsetRing.Prev().Value.(*protocol.ConsumerOffset)
 			timestampDifference := (time.Now().Unix() * 1000) - lastOffset.Timestamp
-			if lastOffset.MaxOffset >= clusterMap.broker[topic][partition].Offset && (timestampDifference >= (storage.app.Config.Lagcheck.MinDistance * 1000)) {
+			clusterMap.brokerLock.RLock()
+			offset := clusterMap.broker[topic][partition].Offset
+			clusterMap.brokerLock.RUnlock()
+			if lastOffset.MaxOffset >= offset && (timestampDifference >= (storage.app.Config.Lagcheck.MinDistance * 1000)) {
 				ringval, _ := offsetRing.Value.(*protocol.ConsumerOffset)
 				ringval.Offset = lastOffset.Offset
 				ringval.MaxOffset = lastOffset.MaxOffset

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"sync"
 	"time"
+	"github.com/Shopify/sarama"
 )
 
 type OffsetStorage struct {
@@ -367,6 +368,43 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 		return
 	}
 
+	groupTopicPartitionOwners := make(map[string]map[int32]string)
+	// Annotating owners only works for v 0.9.0.0 and above
+	if storage.app.Config.ToSaramaKafkaVersion(cluster).IsAtLeast(sarama.V0_9_0_0) {
+		kCluster, ok := storage.app.Clusters[cluster]
+		if !ok {
+			resultChannel <- status
+			return
+		}
+
+		broker, err := kCluster.Client.client.Coordinator(group)
+		if err != nil {
+			log.Errorf("Problem locating coordinator for group %s [%v]", group, err)
+			resultChannel <- status
+			return
+		}
+		groupsResponse, err := broker.DescribeGroups(&sarama.DescribeGroupsRequest{[]string{group}})
+		if err != nil {
+			log.Errorf("Problem describing group for group %s [%v]", group, err)
+			resultChannel <- status
+			return
+		}
+
+		for member, data := range groupsResponse.Groups[0].Members {
+			assignment, _ := data.GetMemberAssignment()
+			for topic, partitions := range assignment.Topics {
+				partitionOwners, ok := groupTopicPartitionOwners[topic]
+				if !ok {
+					partitionOwners = make(map[int32]string)
+				}
+				for _, partition := range partitions {
+					partitionOwners[partition] = member + ":" + data.ClientHost
+				}
+				groupTopicPartitionOwners[topic] = partitionOwners
+			}
+		}
+	}
+
 	// Make sure the group even exists
 	clusterMap.consumerLock.Lock()
 	consumerMap, ok := clusterMap.consumer[group]
@@ -464,6 +502,12 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 				End:       lastOffset,
 			}
 
+			if p, topicExists := groupTopicPartitionOwners[topic]; topicExists {
+				if owner, partExists := p[int32(partition)]; partExists {
+					thispart.Owner = owner
+				}
+			}
+
 			// Check if this partition is the one with the most lag currently
 			if lastOffset.Lag > maxlag {
 				status.Maxlag = thispart
@@ -548,7 +592,7 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 func (storage *OffsetStorage) requestClusterList(request *RequestClusterList) {
 	clusterList := make([]string, len(storage.offsets))
 	i := 0
-	for group, _ := range storage.offsets {
+	for group := range storage.offsets {
 		clusterList[i] = group
 		i += 1
 	}

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -370,7 +370,7 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 
 	groupTopicPartitionOwners := make(map[string]map[int32]string)
 	// Annotating owners only works for v 0.9.0.0 and above
-	if storage.app.Config.ToKafkaVersion(cluster).IsAtLeast(V0_9_0_0) {
+	if storage.app.Config.ToSaramaKafkaVersion(cluster).IsAtLeast(sarama.V0_9_0_0) {
 		kCluster, ok := storage.app.Clusters[cluster]
 		if !ok {
 			resultChannel <- status

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -370,7 +370,7 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 
 	groupTopicPartitionOwners := make(map[string]map[int32]string)
 	// Annotating owners only works for v 0.9.0.0 and above
-	if storage.app.Config.ToSaramaKafkaVersion(cluster).IsAtLeast(sarama.V0_9_0_0) {
+	if storage.app.Config.ToKafkaVersion(cluster).IsAtLeast(V0_9_0_0) {
 		kCluster, ok := storage.app.Clusters[cluster]
 		if !ok {
 			resultChannel <- status

--- a/offsets_store.go
+++ b/offsets_store.go
@@ -14,7 +14,7 @@ import (
 	"container/ring"
 	"fmt"
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"regexp"
 	"sync"
 	"time"

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -64,6 +64,7 @@ type PartitionStatus struct {
 	Topic     string         `json:"topic"`
 	Partition int32          `json:"partition"`
 	Status    StatusConstant `json:"status"`
+	Owner     string         `json:"owner"`
 	Start     ConsumerOffset `json:"start"`
 	End       ConsumerOffset `json:"end"`
 }

--- a/storm.go
+++ b/storm.go
@@ -14,7 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"github.com/samuel/go-zookeeper/zk"
 	"math/rand"
 	"regexp"

--- a/zookeeper.go
+++ b/zookeeper.go
@@ -12,7 +12,7 @@ package main
 
 import (
 	log "github.com/cihub/seelog"
-	"github.com/linkedin/Burrow/protocol"
+	"github.com/CrowdStrike/Burrow/protocol"
 	"github.com/samuel/go-zookeeper/zk"
 	"math/rand"
 	"strconv"


### PR DESCRIPTION
A common issue with a lagging partition(s) is to be able to investigate the machine that is processing those partitions.  With burrow this information isn't readily apparent.  With this patch we are able to query the kafka based ownership information via the sarama's Broker.DescribeGroups API method.  This patch is smart enough to only query for that information if the version of the kafka  brokers support it.  This of course requires that a new configuration variable be added.