### PR TITLE
reduce the default log level inside a Docker container

### DIFF
--- a/docker-config/logging.cfg
+++ b/docker-config/logging.cfg
@@ -1,4 +1,4 @@
-<seelog minlevel="debug">
+<seelog minlevel="info">
   <outputs formatid="main">
     <rollingfile type="date" filename="/var/tmp/burrow/burrow.log" datepattern="2006-01-02" maxrolls="7" />
   </outputs>


### PR DESCRIPTION
Closes https://github.com/linkedin/Burrow/issues/176

Inside a Docker container the additional debug logging is not really useful. By default most people wont map the log directory to the host system, so the logs are just filling up without ever reading (or cleaning) them. 

The debug log is mostly useful when either developing, or when one encounters a problem. In case one wants to access these logs, they can easily override the setting by providing a custom `logging.cfg` and map the log directory using a Docker volume.