### PR TITLE
Possible fix for Issue #140. Adding a min distance check to the artificial offset creation

### DIFF
--- a/offsets_store.go
+++ b/offsets_store.go
@@ -310,6 +310,7 @@ func (storage *OffsetStorage) addConsumerOffset(offset *protocol.PartitionOffset
 		offset.Cluster, offset.Topic, offset.Partition, offset.Group, offset.Timestamp, offset.Offset,
 		partitionLag)
 
+
 	// Advance the ring pointer
 	consumerTopicMap[offset.Partition] = consumerTopicMap[offset.Partition].Next()
 	clusterOffsets.consumerLock.Unlock()
@@ -383,9 +384,11 @@ func (storage *OffsetStorage) evaluateGroup(cluster string, group string, result
 				continue
 			}
 
-			// Add an artificial offset commit if the consumer has no lag against the current broker offset
+			// Add an artificial offset commit if the consumer has no lag against the current broker offset	AND if the distance away from the
+			// last offset timestamp is outside the MinDistance threshold
 			lastOffset := offsetRing.Prev().Value.(*protocol.ConsumerOffset)
-			if lastOffset.Offset >= clusterMap.broker[topic][partition].Offset {
+			timestampDifference := (time.Now().Unix() * 1000) - lastOffset.Timestamp
+			if lastOffset.Offset >= clusterMap.broker[topic][partition].Offset && (timestampDifference >= (storage.app.Config.Lagcheck.MinDistance * 1000)) {
 				ringval, _ := offsetRing.Value.(*protocol.ConsumerOffset)
 				ringval.Offset = lastOffset.Offset
 				ringval.Timestamp = time.Now().Unix() * 1000


### PR DESCRIPTION
From my testing the artificial offset creation can cause issues with going into and out of STOPPED state intermittently whenever the evaluateGroup function is called.  With this fix ONLY lag evaluations that are outside of the min distance window are added to the ring.