### PR TITLE
Generalize TLS/SSL/HTTPS support

### DIFF
--- a/config.go
+++ b/config.go
@@ -149,20 +149,20 @@ func ReadConfig(cfgFile string) *BurrowConfig {
 
 // Split http://myhost:1234 into http myhost and 1234
 func SplitHttpListen(httpListen string) (string, string, uint16) {
-  listenRegex := regexp.MustCompile("^((https?)://)?([^:]+):([0-9]+)")
-  listenMatch := listenRegex.FindStringSubmatch(httpListen)
-  if listenMatch == nil {
-    return "", "", 0
-  }
-  scheme := listenMatch[2]
-  if scheme == "" {
-    scheme = "http"
-  }
-  port, err :=  strconv.ParseUint(listenMatch[4], 10, 16)
-  if err != nil {
-    return "", "", 0
-  }
-  return scheme, listenMatch[3], uint16(port)
+	listenRegex := regexp.MustCompile("^((https?)://)?([^:]+):([0-9]+)")
+	listenMatch := listenRegex.FindStringSubmatch(httpListen)
+	if listenMatch == nil {
+	  return "", "", 0
+	}
+	scheme := listenMatch[2]
+	if scheme == "" {
+	  scheme = "http"
+	}
+	port, err :=  strconv.ParseUint(listenMatch[4], 10, 16)
+	if err != nil {
+	  return "", "", 0
+	}
+	return scheme, listenMatch[3], uint16(port)
 }
 
 
@@ -356,23 +356,23 @@ func ValidateConfig(app *ApplicationContext) error {
 		app.Config.Lagcheck.StormGroupRefresh = 300
 	}
   // TLS
-  tlsAvailable := false
-  if app.Config.Tls.KeyFile != "" {
-    if !validateFile(app.Config.Tls.KeyFile) {
-      errs = append(errs, "TLS Key file invalid")
-    }
-    if app.Config.Tls.CertFile == "" {
-      errs = append(errs, "TLS Cert file not configured")
-    } else {
-      tlsAvailable = true
-    }
-  }
-  if app.Config.Tls.CertFile != "" && !validateFile(app.Config.Tls.CertFile) {
-    errs = append(errs, "TLS Cert file invalid")
-  }
-  if app.Config.Tls.CAFile != "" && !validateFile(app.Config.Tls.CAFile) {
-    errs = append(errs, "TLS CA file invalid")
-  }
+	tlsAvailable := false
+	if app.Config.Tls.KeyFile != "" {
+	  if !validateFile(app.Config.Tls.KeyFile) {
+	    errs = append(errs, "TLS Key file invalid")
+	  }
+	  if app.Config.Tls.CertFile == "" {
+	    errs = append(errs, "TLS Cert file not configured")
+	  } else {
+	    tlsAvailable = true
+	  }
+	}
+	if app.Config.Tls.CertFile != "" && !validateFile(app.Config.Tls.CertFile) {
+	  errs = append(errs, "TLS Cert file invalid")
+	}
+	if app.Config.Tls.CAFile != "" && !validateFile(app.Config.Tls.CAFile) {
+	  errs = append(errs, "TLS CA file invalid")
+	}
 
 	// HTTP Server
 	if app.Config.Httpserver.Enable {
@@ -386,13 +386,13 @@ func ValidateConfig(app *ApplicationContext) error {
 			if app.Config.Httpserver.Port != 0 {
 				errs = append(errs, "Either HTTP server port or listen can be specified, but not both")
 			}
-      for _, httpListen := range app.Config.Httpserver.Listen {
-        s, _, _ := SplitHttpListen(httpListen)
-        if s == "https" && tlsAvailable == false {
-          errs = append(errs, "HTTPS listener specified, but not TLS configuration")
-          break
-        }
-      }
+			for _, httpListen := range app.Config.Httpserver.Listen {
+				s, _, _ := SplitHttpListen(httpListen)
+				if s == "https" && tlsAvailable == false {
+					errs = append(errs, "HTTPS listener specified, but not TLS configuration")
+					break
+				}
+			}
 		}
 	}
 
@@ -579,8 +579,8 @@ func validateFilename(filename string) bool {
 
 // Verify file exists and is file
 func validateFile(filePath string) bool {
-  fileInfo, err := os.Stat(filePath)
-  return err == nil && fileInfo != nil && fileInfo.Mode().IsRegular()
+	fileInfo, err := os.Stat(filePath)
+	return err == nil && fileInfo != nil && fileInfo.Mode().IsRegular()
 }
 
 // Very simplistic email address validator - just looks for an @ and a .

--- a/config.go
+++ b/config.go
@@ -28,6 +28,15 @@ type ClientProfile struct {
 	ClientID    string `gcfg:"client-id"`
 	TLS         string   `gcfg:"tls"`
 }
+// TLS Configuration
+type TLSConfig struct {
+	CertFile		string `gcfg:"cert-file"`
+	KeyFile			string `gcfg:"key-file"`
+	CAFile			string `gcfg:"ca-file"`
+	NoVerify		bool	 `gcfg:"no-verify"`
+	Ciphers			string `gcfg:"ciphers"`
+	Versions		string `gcfg:"versions"`
+}
 type BurrowConfig struct {
 	General struct {
 		LogDir         string `gcfg:"logdir"`
@@ -71,12 +80,7 @@ type BurrowConfig struct {
 		StormCheck        int64 `gcfg:"storm-interval"`
 		StormGroupRefresh int64 `gcfg:"storm-group-refresh"`
 	}
-	Tls map[string]*struct {
-		CertFile		string `gcfg:"cert-file"`
-		KeyFile			string `gcfg:"key-file"`
-		CAFile			string `gcfg:"ca-file"`
-		NoVerify		bool	 `gcfg:"no-verify"`
-	}
+	Tls map[string]*TLSConfig
 	Httpserver struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`

--- a/config.go
+++ b/config.go
@@ -120,6 +120,7 @@ type BurrowConfig struct {
 		PostThreshold  int      `gcfg:"post-threshold"`
 		Timeout        int      `gcfg:"timeout"`
 		Keepalive      int      `gcfg:"keepalive"`
+		TLS            string   `gcfg:"tls"`
 	}
 	Slacknotifier struct {
 		Enable    bool     `gcfg:"enable"`

--- a/config.go
+++ b/config.go
@@ -71,6 +71,11 @@ type BurrowConfig struct {
 		StormCheck        int64 `gcfg:"storm-interval"`
 		StormGroupRefresh int64 `gcfg:"storm-group-refresh"`
 	}
+	Tls struct {
+		CertFile string `gcfg:"cert-file"`
+		KeyFile string `gcfg:"key-file"`
+		CAFile string `gcfg:"ca-file"`
+	}
 	Httpserver struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`
@@ -141,6 +146,25 @@ func ReadConfig(cfgFile string) *BurrowConfig {
 	}
 	return &cfg
 }
+
+// Split http://myhost:1234 into http myhost and 1234
+func SplitHttpListen(httpListen string) (string, string, uint16) {
+  listenRegex := regexp.MustCompile("^((https?)://)?([^:]+):([0-9]+)")
+  listenMatch := listenRegex.FindStringSubmatch(httpListen)
+  if listenMatch == nil {
+    return "", "", 0
+  }
+  scheme := listenMatch[2]
+  if scheme == "" {
+    scheme = "http"
+  }
+  port, err :=  strconv.ParseUint(listenMatch[4], 10, 16)
+  if err != nil {
+    return "", "", 0
+  }
+  return scheme, listenMatch[3], uint16(port)
+}
+
 
 // Validate that the config is complete
 // For a couple values, this will set reasonable defaults for missing values
@@ -331,6 +355,24 @@ func ValidateConfig(app *ApplicationContext) error {
 	if app.Config.Lagcheck.StormGroupRefresh == 0 {
 		app.Config.Lagcheck.StormGroupRefresh = 300
 	}
+  // TLS
+  tlsAvailable := false
+  if app.Config.Tls.KeyFile != "" {
+    if !validateFile(app.Config.Tls.KeyFile) {
+      errs = append(errs, "TLS Key file invalid")
+    }
+    if app.Config.Tls.CertFile == "" {
+      errs = append(errs, "TLS Cert file not configured")
+    } else {
+      tlsAvailable = true
+    }
+  }
+  if app.Config.Tls.CertFile != "" && !validateFile(app.Config.Tls.CertFile) {
+    errs = append(errs, "TLS Cert file invalid")
+  }
+  if app.Config.Tls.CAFile != "" && !validateFile(app.Config.Tls.CAFile) {
+    errs = append(errs, "TLS CA file invalid")
+  }
 
 	// HTTP Server
 	if app.Config.Httpserver.Enable {
@@ -344,6 +386,13 @@ func ValidateConfig(app *ApplicationContext) error {
 			if app.Config.Httpserver.Port != 0 {
 				errs = append(errs, "Either HTTP server port or listen can be specified, but not both")
 			}
+      for _, httpListen := range app.Config.Httpserver.Listen {
+        s, _, _ := SplitHttpListen(httpListen)
+        if s == "https" && tlsAvailable == false {
+          errs = append(errs, "HTTPS listener specified, but not TLS configuration")
+          break
+        }
+      }
 		}
 	}
 
@@ -526,6 +575,12 @@ func validateTopic(topic string) bool {
 func validateFilename(filename string) bool {
 	matches, _ := regexp.MatchString(`^[a-zA-Z0-9_\.-]+$`, filename)
 	return matches
+}
+
+// Verify file exists and is file
+func validateFile(filePath string) bool {
+  fileInfo, err := os.Stat(filePath)
+  return err == nil && fileInfo != nil && fileInfo.Mode().IsRegular()
 }
 
 // Very simplistic email address validator - just looks for an @ and a .

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -14,6 +14,20 @@ port=2181
 timeout=6
 lock-path=/burrow/notifier
 
+[tls "server"]
+key-file=config/host.key
+cert-file=config/host.cert
+ca-file=config/ca.pem
+
+[tls "client"]
+ca-file=config/ca.pem
+no-verify=true
+
+[clientprofile "tlsclient"]
+client-id=burrow-client
+; See [tls "client"] above
+tls=client
+
 [kafka "local"]
 broker=kafka01.example.com
 broker=kafka02.example.com
@@ -27,6 +41,7 @@ zookeeper=zkhost03.example.com
 zookeeper-port=2181
 zookeeper-path=/kafka-cluster
 offsets-topic=__consumer_offsets
+; client-profile=tlsclient
 
 [storm "local"]
 zookeeper=zkhost01.example.com
@@ -48,6 +63,9 @@ port=8000
 ; Alternatively, use listen (cannot be specified when port is)
 ; listen=host:port
 ; listen=host2:port2
+; See [tls "server"] section
+; tls=server
+; listen=https://host3:port3
 
 [smtp]
 server=mailserver.example.com

--- a/config_test.go
+++ b/config_test.go
@@ -1,20 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
-
-func assertStringEqual(t *testing.T, expected string, actual string) {
-	if expected != actual {
-		t.Error(fmt.Sprintf("Expected string \"%s\", got \"%s\"", expected, actual))
-	}
-}
-func assertUInt16Equal(t *testing.T, expected uint16, actual uint16) {
-	if expected != actual {
-		t.Error(fmt.Sprintf("Expected uint16 \"%d\", got \"%d\"", expected, actual))
-	}
-}
 
 func TestSplitHttpListen(t *testing.T) {
 	t.Log("Basic URL")

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func assertStringEqual(t *testing.T, expected string, actual string) {
+	if expected != actual {
+		t.Error(fmt.Sprintf("Expected string \"%s\", got \"%s\"", expected, actual))
+	}
+}
+func assertUInt16Equal(t *testing.T, expected uint16, actual uint16) {
+	if expected != actual {
+		t.Error(fmt.Sprintf("Expected uint16 \"%d\", got \"%d\"", expected, actual))
+	}
+}
+
+func TestSplitHttpListen(t *testing.T) {
+	t.Log("Basic URL")
+	scheme, host, port := SplitHttpListen("http://myhost:1234")
+	assertStringEqual(t, "http", scheme)
+	assertStringEqual(t, "myhost", host)
+	assertUInt16Equal(t, 1234, port)
+
+	t.Log("HTTPS URL")
+	scheme, host, port = SplitHttpListen("https://myhost:1234")
+	assertStringEqual(t, "https", scheme)
+	assertStringEqual(t, "myhost", host)
+	assertUInt16Equal(t, 1234, port)
+
+	t.Log("Invalid FTPS URL")
+	scheme, host, port = SplitHttpListen("ftp://myhost:1234")
+	assertStringEqual(t, "", scheme)
+	assertUInt16Equal(t, 0, port)
+
+	t.Log("Scheme-less URL")
+	scheme, host, port = SplitHttpListen("myhost:1234")
+	assertStringEqual(t, "http", scheme)
+	assertStringEqual(t, "myhost", host)
+	assertUInt16Equal(t, 1234, port)
+
+	t.Log("Invalid Port-less URL")
+	scheme, host, port = SplitHttpListen("myhost:abcd")
+	assertStringEqual(t, "", scheme)
+	assertUInt16Equal(t, 0, port)
+}

--- a/http_server.go
+++ b/http_server.go
@@ -20,7 +20,7 @@ import (
 	"net"
 	"time"
 	log "github.com/cihub/seelog"
-  "crypto/tls"
+	"crypto/tls"
 	"fmt"
 )
 
@@ -54,17 +54,17 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 }
 
 func newHttpListener(listenAddress string, config *BurrowConfig) (net.Listener, error) {
-  scheme, host, port := SplitHttpListen(listenAddress)
-  listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
-  listen = tcpKeepAliveListener{listen.(*net.TCPListener)}
-  if scheme == "https" {
-    tlsConfig, err := NewTLSConfig(config)
-    if err != nil {
-      return nil, err
-    }
-    listen = tls.NewListener(listen, tlsConfig)
-  }
-  return listen, err
+	scheme, host, port := SplitHttpListen(listenAddress)
+	listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+	listen = tcpKeepAliveListener{listen.(*net.TCPListener)}
+	if scheme == "https" {
+		tlsConfig, err := NewTLSConfig(config)
+		if err != nil {
+			return nil, err
+		}
+		listen = tls.NewListener(listen, tlsConfig)
+	}
+	return listen, err
 }
 
 func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
@@ -87,7 +87,7 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 
 	listeners := make([]net.Listener, 0, len(server.app.Config.Httpserver.Listen))
 	for _, listenAddress := range server.app.Config.Httpserver.Listen {
-    ln, err := newHttpListener(listenAddress, server.app.Config)
+		ln, err := newHttpListener(listenAddress, server.app.Config)
 		if err != nil {
 			for _, listenerToClose := range listeners {
 				closeErr := listenerToClose.Close()

--- a/http_server.go
+++ b/http_server.go
@@ -58,7 +58,7 @@ func newHttpListener(listenAddress string, config *BurrowConfig) (net.Listener, 
 	listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
 	listen = tcpKeepAliveListener{listen.(*net.TCPListener)}
 	if scheme == "https" {
-		tlsConfig, err := NewTLSConfig(config)
+		tlsConfig, err := NewTLSConfig(config, config.Httpserver.TLS)
 		if err != nil {
 			return nil, err
 		}

--- a/http_server.go
+++ b/http_server.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"time"
 	log "github.com/cihub/seelog"
+  "crypto/tls"
+	"fmt"
 )
 
 type HttpServer struct {
@@ -51,6 +53,20 @@ func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
 	return tc, nil
 }
 
+func newHttpListener(listenAddress string, config *BurrowConfig) (net.Listener, error) {
+  scheme, host, port := SplitHttpListen(listenAddress)
+  listen, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+  listen = tcpKeepAliveListener{listen.(*net.TCPListener)}
+  if scheme == "https" {
+    tlsConfig, err := NewTLSConfig(config)
+    if err != nil {
+      return nil, err
+    }
+    listen = tls.NewListener(listen, tlsConfig)
+  }
+  return listen, err
+}
+
 func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 	server := &HttpServer{
 		app: app,
@@ -70,9 +86,8 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 	// server.mux.Handle("/v2/zookeeper/", appHandler{server.app, handleZookeeper})
 
 	listeners := make([]net.Listener, 0, len(server.app.Config.Httpserver.Listen))
-
 	for _, listenAddress := range server.app.Config.Httpserver.Listen {
-		ln, err := net.Listen("tcp", listenAddress)
+    ln, err := newHttpListener(listenAddress, server.app.Config)
 		if err != nil {
 			for _, listenerToClose := range listeners {
 				closeErr := listenerToClose.Close()
@@ -82,7 +97,7 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 			}
 			return nil, err
 		}
-		listeners = append(listeners, tcpKeepAliveListener{ln.(*net.TCPListener)})
+		listeners = append(listeners, ln)
 	}
 
 	httpServer := &http.Server{Handler: server.mux}

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -48,14 +48,14 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
 	clientConfig.Net.TLS.Enable = profile.TLS
-  if clientConfig.Net.TLS.Enable {
-	  tlsConfig, err := NewTLSConfig(app.Config)
-    if err != nil {
-      return nil, err
-    }
-    clientConfig.Net.TLS.Config = tlsConfig
-	  clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
-  }
+	if clientConfig.Net.TLS.Enable {
+		tlsConfig, err := NewTLSConfig(app.Config)
+		if err != nil {
+			return nil, err
+		}
+		clientConfig.Net.TLS.Config = tlsConfig
+		clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
+	}
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -47,14 +47,13 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	clientConfig := sarama.NewConfig()
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
-	clientConfig.Net.TLS.Enable = profile.TLS
+	clientConfig.Net.TLS.Enable = (profile.TLS != "")
 	if clientConfig.Net.TLS.Enable {
-		tlsConfig, err := NewTLSConfig(app.Config)
+		tlsConfig, err := NewTLSConfig(app.Config, profile.TLS)
 		if err != nil {
 			return nil, err
 		}
 		clientConfig.Net.TLS.Config = tlsConfig
-		clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
 	}
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"github.com/Shopify/sarama"
@@ -49,8 +48,14 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	profile := app.Config.Clientprofile[app.Config.Kafka[cluster].Clientprofile]
 	clientConfig.ClientID = profile.ClientID
 	clientConfig.Net.TLS.Enable = profile.TLS
-	clientConfig.Net.TLS.Config = &tls.Config{}
-	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
+  if clientConfig.Net.TLS.Enable {
+	  tlsConfig, err := NewTLSConfig(app.Config)
+    if err != nil {
+      return nil, err
+    }
+    clientConfig.Net.TLS.Config = tlsConfig
+	  clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
+  }
 
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,31 @@ package main
 
 import (
 	"testing"
+	"fmt"
 )
+
+func assertStringEqual(t *testing.T, expected string, actual string) {
+	if expected != actual {
+		t.Error(fmt.Sprintf("Expected string \"%s\", got \"%s\"", expected, actual))
+	}
+}
+func assertUInt16Equal(t *testing.T, expected uint16, actual uint16) {
+	if expected != actual {
+		t.Error(fmt.Sprintf("Expected uint16 \"%d\", got \"%d\"", expected, actual))
+	}
+}
+
+func assertIntEqual(t *testing.T, expected int, actual int) {
+	if expected != actual {
+		t.Error(fmt.Sprintf("Expected int \"%d\", got \"%d\"", expected, actual))
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Error(fmt.Sprintf("Unxpected error %s", err))
+	}
+}
 
 // This is just a dummy test function to have a base to start with for Travis
 func Test_dummy(t *testing.T) {

--- a/notify_center.go
+++ b/notify_center.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"crypto/tls"
 	log "github.com/cihub/seelog"
 	"github.com/linkedin/Burrow/notifier"
 	"github.com/linkedin/Burrow/protocol"
@@ -217,6 +218,16 @@ func NewHttpNotifier(app *ApplicationContext) (*notifier.HttpNotifier, error) {
 		extras[parts[0]] = parts[1]
 	}
 
+	// Prepare TLS Config
+	var tlsConfig *tls.Config
+	if app.Config.Httpnotifier.TLS != "" {
+		var err error
+		tlsConfig, err = NewTLSConfig(app.Config, app.Config.Httpnotifier.TLS)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &notifier.HttpNotifier{
 		RequestOpen: notifier.HttpNotifierRequest{
 			Url:          httpConfig.UrlOpen,
@@ -238,6 +249,7 @@ func NewHttpNotifier(app *ApplicationContext) (*notifier.HttpNotifier, error) {
 					KeepAlive: time.Duration(httpConfig.Keepalive) * time.Second,
 				}).Dial,
 				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: tlsConfig,
 			},
 		},
 	}, nil

--- a/tls.go
+++ b/tls.go
@@ -7,18 +7,20 @@ import (
 )
 
 // Create TLS Config from application config file
-func NewTLSConfig(appConfig *BurrowConfig) (*tls.Config, error) {
-	tlsConfig := &tls.Config{}
-	if appConfig.Tls.CertFile != "" && appConfig.Tls.KeyFile != "" {
-		keyPair, err := tls.LoadX509KeyPair(appConfig.Tls.CertFile, appConfig.Tls.KeyFile)
+func NewTLSConfig(appConfig *BurrowConfig, name string) (*tls.Config, error) {
+	config, _ := appConfig.Tls[name]
+	tlsConfig := &tls.Config{InsecureSkipVerify: config.NoVerify}
+	if config.CertFile != "" && config.KeyFile != "" {
+		keyPair, err := tls.LoadX509KeyPair(config.CertFile, config.KeyFile)
 		if err != nil {
 			return nil, err
 		}
 		tlsConfig.Certificates = []tls.Certificate{keyPair}
+		tlsConfig.BuildNameToCertificate()
 	}
-	if appConfig.Tls.CAFile != "" {
+	if config.CAFile != "" {
 		cas := x509.NewCertPool()
-		caCerts, err := ioutil.ReadFile(appConfig.Tls.CAFile)
+		caCerts, err := ioutil.ReadFile(config.CAFile)
 		if err != nil {
 			return nil, err
 		}

--- a/tls.go
+++ b/tls.go
@@ -4,6 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"strings"
+	"errors"
+	"fmt"
 )
 
 // Create TLS Config from application config file
@@ -27,5 +30,87 @@ func NewTLSConfig(appConfig *BurrowConfig, name string) (*tls.Config, error) {
 		cas.AppendCertsFromPEM(caCerts)
 		tlsConfig.RootCAs = cas
 	}
+	// Configure Version
+	if config.Versions != "" {
+		versionMin, versionMax, err := convertTLSVersions(config.Versions)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.MinVersion = versionMin
+		tlsConfig.MaxVersion = versionMax
+	}
+	// Configure Cipher suites
+	if config.Ciphers != "" {
+		ciphers, err := convertTLSCiphers(config.Ciphers)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.CipherSuites = ciphers
+	}
 	return tlsConfig, nil
+}
+
+func convertTLSVersions(versions string) (versionMin uint16, versionMax uint16, err error) {
+	versionMap := map[string]uint16{
+		"SSLv3": tls.VersionSSL30,
+		"SSLv3.0": tls.VersionSSL30,
+		"TLSv1.0": tls.VersionTLS10,
+		"TLSv1.1": tls.VersionTLS11,
+		"TLSv1.2": tls.VersionTLS12,
+	}
+	versionNames := strings.Split(versions,",")
+	versionMin, versionMax = tls.VersionTLS12, tls.VersionSSL30
+	for _,versionName := range versionNames {
+		versionName = strings.TrimSpace(versionName)
+		version, ok := versionMap[versionName]
+		if !ok {
+			return 0, 0, errors.New(fmt.Sprintf("TLS Version %s unsupported", versionName))
+		}
+		if version < versionMin {
+			versionMin = version
+		}
+		if version > versionMax {
+			versionMax = version
+		}
+	}
+	return
+}
+
+func convertTLSCiphers(ciphers string) ( cipherList[]uint16, err error) {
+	// Some ciphers are not supported in Golang 1.6
+	cipherMap := map[string]uint16{
+		"RSA_WITH_RC4_128_SHA": tls.TLS_RSA_WITH_RC4_128_SHA,
+		"RSA_WITH_3DES_EDE_CBC_SHA": tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+		"RSA_WITH_AES_128_CBC_SHA": tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+		"RSA_WITH_AES_256_CBC_SHA": tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		// "RSA_WITH_AES_128_CBC_SHA256": tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+		"RSA_WITH_AES_128_GCM_SHA256": tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		"RSA_WITH_AES_256_GCM_SHA384": tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE_ECDSA_WITH_RC4_128_SHA": tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA,
+		"ECDHE_ECDSA_WITH_AES_128_CBC_SHA": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		"ECDHE_ECDSA_WITH_AES_256_CBC_SHA": tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		"ECDHE_RSA_WITH_RC4_128_SHA": tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA,
+		"ECDHE_RSA_WITH_3DES_EDE_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+		"ECDHE_RSA_WITH_AES_128_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		"ECDHE_RSA_WITH_AES_256_CBC_SHA": tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		// "ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+		// "ECDHE_RSA_WITH_AES_128_CBC_SHA256": tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+		"ECDHE_RSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"ECDHE_RSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		// "ECDHE_RSA_WITH_CHACHA20_POLY1305": tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		// "ECDHE_ECDSA_WITH_CHACHA20_POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+	}
+	cipherNames := strings.Split(ciphers,",")
+	cipherList = make([]uint16, len(cipherNames))
+	for i,cipherName := range cipherNames {
+		cipherName = strings.TrimSpace(cipherName)
+		cipher, ok := cipherMap[cipherName]
+		if !ok {
+			return nil, errors.New(fmt.Sprintf("TLS Cipher %s unsupported", cipherName))
+		}
+		cipherList[i] = cipher
+	}
+	return
 }

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+)
+
+// Create TLS Config from application config file
+func NewTLSConfig(appConfig *BurrowConfig) (*tls.Config, error) {
+	tlsConfig := &tls.Config{}
+	if appConfig.Tls.CertFile != "" && appConfig.Tls.KeyFile != "" {
+		keyPair, err := tls.LoadX509KeyPair(appConfig.Tls.CertFile, appConfig.Tls.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{keyPair}
+	}
+	if appConfig.Tls.CAFile != "" {
+		cas := x509.NewCertPool()
+		caCerts, err := ioutil.ReadFile(appConfig.Tls.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		cas.AppendCertsFromPEM(caCerts)
+		tlsConfig.RootCAs = cas
+	}
+	return tlsConfig, nil
+}

--- a/tls_test.go
+++ b/tls_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func TestNewTLSConfig_Ciphers(t *testing.T) {
+	config := &BurrowConfig{}
+	config.Tls = map[string]*TLSConfig{
+		"default": &TLSConfig{Ciphers: "RSA_WITH_AES_256_GCM_SHA384,ECDHE_ECDSA_WITH_AES_256_CBC_SHA"},
+	}
+	tlsConfig, err := NewTLSConfig(config, "default")
+	assertNoError(t, err)
+	assertIntEqual(t, 2, len(tlsConfig.CipherSuites))
+	assertUInt16Equal(t, tls.TLS_RSA_WITH_AES_256_GCM_SHA384, tlsConfig.CipherSuites[0])
+	assertUInt16Equal(t, tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, tlsConfig.CipherSuites[1])
+}
+
+func TestNewTLSConfig_Versions(t *testing.T) {
+	config := &BurrowConfig{}
+	config.Tls = map[string]*TLSConfig{
+		"default": &TLSConfig{Versions: "TLSv1.0,TLSv1.1"},
+	}
+	tlsConfig, err := NewTLSConfig(config, "default")
+	assertNoError(t, err)
+	assertUInt16Equal(t, tls.VersionTLS10, tlsConfig.MinVersion)
+	assertUInt16Equal(t, tls.VersionTLS11, tlsConfig.MaxVersion)
+}


### PR DESCRIPTION
Generalizes https://github.com/linkedin/Burrow/pull/160
Moves TLS config code from kafka_client.go to tls.go in order to share it with HTTP server

- [X] SSL support in Kafka Client
- [X] HTTPS support in HTTP server
- [X] HTTPS support in HTTP client
- [X] Don't verify hostname
- [X] Choose TLS version
- [X] Choose Cipher suites