### PR TITLE
Add Basic Auth to HTTP Server

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -3,3 +3,5 @@ github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
+github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
+golang.org/x/crypto/bcrypt          728b753d0135da6801d45a38e6f43ff55779c5c2

--- a/Godeps
+++ b/Godeps
@@ -3,5 +3,4 @@ github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
-github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
 golang.org/x/crypto/bcrypt          728b753d0135da6801d45a38e6f43ff55779c5c2

--- a/config.go
+++ b/config.go
@@ -79,6 +79,9 @@ type BurrowConfig struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`
 		Listen []string `gcfg:"listen"`
+		BasicAuthEnabled bool 					`gcfg:"basic-auth-enabled"`
+		BasicAuthAnonymousRole string		`gcfg:"basic-auth-anonymous-role"`
+		BasicAuthUserConfigFile string  `gcfg:"basic-auth-user-config-file"`
 	}
 	Notify struct {
 		Interval int64 `gcfg:"interval"`

--- a/config.go
+++ b/config.go
@@ -82,6 +82,7 @@ type BurrowConfig struct {
 		BasicAuthEnabled bool 					`gcfg:"basic-auth-enabled"`
 		BasicAuthAnonymousRole string		`gcfg:"basic-auth-anonymous-role"`
 		BasicAuthUserConfigFile string  `gcfg:"basic-auth-user-config-file"`
+		BasicAuthUserPasswordHash string  `gcfg:"basic-auth-user-password-hash"`
 		BasicAuthRealmName string  `gcfg:"basic-auth-realm-name"`
 	}
 	Notify struct {
@@ -360,6 +361,9 @@ func ValidateConfig(app *ApplicationContext) error {
 			if app.Config.Httpserver.BasicAuthUserConfigFile != "" {
 				if _, err := os.Stat(app.Config.Httpserver.BasicAuthUserConfigFile); os.IsNotExist(err) {
 					errs = append(errs, "Basic Auth Users File not found")
+				}
+				if app.Config.Httpserver.BasicAuthUserPasswordHash == "" {
+					app.Config.Httpserver.BasicAuthUserPasswordHash = "sha256"
 				}
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -82,6 +82,7 @@ type BurrowConfig struct {
 		BasicAuthEnabled bool 					`gcfg:"basic-auth-enabled"`
 		BasicAuthAnonymousRole string		`gcfg:"basic-auth-anonymous-role"`
 		BasicAuthUserConfigFile string  `gcfg:"basic-auth-user-config-file"`
+		BasicAuthRealmName string  `gcfg:"basic-auth-realm-name"`
 	}
 	Notify struct {
 		Interval int64 `gcfg:"interval"`
@@ -350,6 +351,16 @@ func ValidateConfig(app *ApplicationContext) error {
 		} else {
 			if app.Config.Httpserver.Port != 0 {
 				errs = append(errs, "Either HTTP server port or listen can be specified, but not both")
+			}
+		}
+		if app.Config.Httpserver.BasicAuthEnabled {
+			if app.Config.Httpserver.BasicAuthAnonymousRole == "" && app.Config.Httpserver.BasicAuthUserConfigFile == "" {
+				errs = append(errs, "Basic Auth Enabled, either Anonymous Role or User Config must be configured")
+			}
+			if app.Config.Httpserver.BasicAuthUserConfigFile != "" {
+				if _, err := os.Stat(app.Config.Httpserver.BasicAuthUserConfigFile); os.IsNotExist(err) {
+					errs = append(errs, "Basic Auth Users File not found")
+				}
 			}
 		}
 	}

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -48,6 +48,10 @@ port=8000
 ; Alternatively, use listen (cannot be specified when port is)
 ; listen=host:port
 ; listen=host2:port2
+; basic-auth-enabled=true
+; basic-auth-realm-name=Burrow
+; basic-auth-anonymous-role=USER
+; basic-auth-user-config-file=config/user.cfg
 
 [smtp]
 server=mailserver.example.com

--- a/config/user.cfg
+++ b/config/user.cfg
@@ -1,10 +1,10 @@
 [user "admin"]
-; Below is password "admin" hashed with bcrypt
-password=$2a$10$3UnR.2F.FV8IlZCX2jAABOExg0JXMoTG/uvh/mLyzMi1NWkUA4va6
+; Below is password "admin" hashed with SHA256
+password=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
 role=ADMIN
 role=USER
 
 [user "user"]
-; Below is password "user" hashed with bcrypt
-password=$2a$10$FMPaP5HuwFJlV2sryzpzX.SylBvkwHHjS84LsBka/EfFysASWfHx.
+; Below is password "user" hashed with SHA256
+password=04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb
 role=USER

--- a/config/user.cfg
+++ b/config/user.cfg
@@ -1,0 +1,10 @@
+[user "admin"]
+; Below is password "admin" hashed with bcrypt
+password=$2a$10$3UnR.2F.FV8IlZCX2jAABOExg0JXMoTG/uvh/mLyzMi1NWkUA4va6
+role=ADMIN
+role=USER
+
+[user "user"]
+; Below is password "user" hashed with bcrypt
+password=$2a$10$FMPaP5HuwFJlV2sryzpzX.SylBvkwHHjS84LsBka/EfFysASWfHx.
+role=USER

--- a/go-test.sh
+++ b/go-test.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+red="$(printf '\033[0;31m')"
+green="$(printf '\033[0;32m')"
+normal="$(printf '\033[0;39m')"
+
 test_dirs=$(find . -name '*_test.go' | xargs -n1 dirname |uniq)
 for test_dir in ${test_dirs}; do
   echo "Running tests in ${test_dir}"
-  go test -v ${test_dir}
+  go test -v ${test_dir} | sed -e "s/PASS/${green}PASS${normal}/g" -e "s/FAIL/${red}FAIL${normal}/g"
   echo
 done

--- a/go-test.sh
+++ b/go-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+test_dirs=$(find . -name '*_test.go' | xargs -n1 dirname |uniq)
+for test_dir in ${test_dirs}; do
+  echo "Running tests in ${test_dir}"
+  go test -v ${test_dir}
+  echo
+done

--- a/http_server.go
+++ b/http_server.go
@@ -68,6 +68,7 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 
 	// User checker
 	userChecker, err := security.NewUserChecker(app.Config.Httpserver.BasicAuthEnabled,
+		app.Config.Httpserver.BasicAuthRealmName,
 		app.Config.Httpserver.BasicAuthUserConfigFile,
 		app.Config.Httpserver.BasicAuthAnonymousRole)
 	if err != nil {
@@ -117,7 +118,7 @@ func (ah appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if !authorized {
 			w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=\"%s\"", ah.userChecker.RealmName))
-			http.Error(w, "{\"error\":true,\"message\":\"request method not supported\",\"result\":{}}", http.StatusUnauthorized)
+			http.Error(w, "{\"error\":true,\"message\":\"request not authorized\",\"result\":{}}", http.StatusForbidden)
 			return
 		}
 	}

--- a/http_server.go
+++ b/http_server.go
@@ -70,6 +70,7 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 	userChecker, err := security.NewUserChecker(app.Config.Httpserver.BasicAuthEnabled,
 		app.Config.Httpserver.BasicAuthRealmName,
 		app.Config.Httpserver.BasicAuthUserConfigFile,
+		app.Config.Httpserver.BasicAuthUserPasswordHash,
 		app.Config.Httpserver.BasicAuthAnonymousRole)
 	if err != nil {
 		return nil, err

--- a/security/_test/user.cfg
+++ b/security/_test/user.cfg
@@ -1,10 +1,10 @@
 [user "admin"]
-; Below is password "admin" hashed with bcrypt
-password=$2a$10$3UnR.2F.FV8IlZCX2jAABOExg0JXMoTG/uvh/mLyzMi1NWkUA4va6
+; Below is password "admin" hashed with SHA256
+password=8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
 role=ADMIN
 role=USER
 
 [user "user"]
-; Below is password "user" hashed with bcrypt
-password=$2a$10$FMPaP5HuwFJlV2sryzpzX.SylBvkwHHjS84LsBka/EfFysASWfHx.
+; Below is password "user" hashed with SHA256
+password=04f8996da763b7a969b1028ee3007569eaf3a635486ddab211d512c85b9df8fb
 role=USER

--- a/security/_test/user.cfg
+++ b/security/_test/user.cfg
@@ -1,0 +1,10 @@
+[user "admin"]
+; Below is password "admin" hashed with bcrypt
+password=$2a$10$3UnR.2F.FV8IlZCX2jAABOExg0JXMoTG/uvh/mLyzMi1NWkUA4va6
+role=ADMIN
+role=USER
+
+[user "user"]
+; Below is password "user" hashed with bcrypt
+password=$2a$10$FMPaP5HuwFJlV2sryzpzX.SylBvkwHHjS84LsBka/EfFysASWfHx.
+role=USER

--- a/security/_test/user_bcrypt.cfg
+++ b/security/_test/user_bcrypt.cfg
@@ -1,0 +1,10 @@
+[user "admin"]
+; Below is password "admin" hashed with bcrypt
+password=$2a$10$3UnR.2F.FV8IlZCX2jAABOExg0JXMoTG/uvh/mLyzMi1NWkUA4va6
+role=ADMIN
+role=USER
+
+[user "user"]
+; Below is password "user" hashed with bcrypt
+password=$2a$10$FMPaP5HuwFJlV2sryzpzX.SylBvkwHHjS84LsBka/EfFysASWfHx.
+role=USER

--- a/security/anonymous_realm.go
+++ b/security/anonymous_realm.go
@@ -1,0 +1,12 @@
+package security
+
+type AnonymousRealm struct {
+	Role string
+}
+
+func (r *AnonymousRealm) Authenticate(username, password string) (*User, error) {
+	if username != "" {
+		return nil, nil
+	}
+	return &User{Roles:[]string{r.Role}}, nil
+}

--- a/security/anonymous_realm_test.go
+++ b/security/anonymous_realm_test.go
@@ -1,0 +1,35 @@
+package security
+
+import (
+	"testing"
+)
+
+func TestAnonymousRealm(t *testing.T) {
+	var realm Realm
+	var user *User
+	realm = &AnonymousRealm{Role: "USER"}
+
+	user, _ = realm.Authenticate("", "")
+	if user ==nil {
+		t.Error("Anonymous should be authenticated")
+	}
+	if !user.IsAuthorized("GET", "/some/path") {
+		t.Error("Anonymous should be authorized to GET /some/path")
+	}
+	if user.IsAuthorized("DELETE", "/some/path") {
+		t.Error("Anonymous shouldn't be authorized to DELETE /some/path")
+	}
+}
+
+func TestAnonymousRealm_User(t *testing.T) {
+	var realm Realm
+	var user *User
+
+	realm = &AnonymousRealm{Role: "USER"}
+
+	user, _ = realm.Authenticate("user", "password")
+
+	if user != nil {
+		t.Error("User shouldn't authenticate")
+	}
+}

--- a/security/file_realm.go
+++ b/security/file_realm.go
@@ -1,0 +1,46 @@
+package security
+
+import (
+	"golang.org/x/crypto/bcrypt"
+	//"errors"
+	"gopkg.in/gcfg.v1"
+)
+
+type FileRealm struct {
+	Config UserConfig
+}
+
+type FileUser struct {
+	Password string   `gcfg:"password"`
+	Role     []string `gcfg:"role"`
+}
+
+type UserConfig struct {
+	User map[string]*FileUser
+}
+
+func NewFileRealm(userConfigFile string) (*FileRealm, error) {
+	realm := &FileRealm{}
+	err := gcfg.ReadFileInto(&realm.Config, userConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	return realm, nil
+}
+
+func (r *FileRealm) Authenticate(username, password string) (*User, error) {
+	if username == "" {
+		return nil, nil
+	}
+	user, ok := r.Config.User[username]
+	if !ok {
+		return nil, nil
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
+		return nil, err
+	}
+	//if user.Password != password {
+	//	return nil, errors.New("Invalid password")
+	//}
+	return &User{Name: username, Roles: user.Role}, nil
+}

--- a/security/file_realm.go
+++ b/security/file_realm.go
@@ -2,12 +2,18 @@ package security
 
 import (
 	"golang.org/x/crypto/bcrypt"
-	//"errors"
+	"crypto"
+	"encoding/hex"
 	"gopkg.in/gcfg.v1"
+	"errors"
+	"strings"
+	"fmt"
 )
 
 type FileRealm struct {
 	Config UserConfig
+	HashFunc string
+	passwordVerifier passwordVerifier
 }
 
 type FileUser struct {
@@ -19,14 +25,61 @@ type UserConfig struct {
 	User map[string]*FileUser
 }
 
-func NewFileRealm(userConfigFile string) (*FileRealm, error) {
+type passwordVerifier interface {
+	compareHashAndPassword(hash string, password string) error
+}
+
+type cryptoPasswordVerifier struct {
+	hash crypto.Hash
+}
+
+func (v *cryptoPasswordVerifier) compareHashAndPassword(hash string, password string) error {
+	hashBuilder := v.hash.New()
+	hashBuilder.Write([]byte(password))
+	hashedPassword := hex.EncodeToString(hashBuilder.Sum(nil))
+	if hashedPassword != hash {
+		return errors.New("Invalid password")
+	}
+	return nil
+}
+
+type bcryptPasswordVerifier struct {
+
+}
+
+func (v *bcryptPasswordVerifier) compareHashAndPassword(hash string, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}
+
+func NewFileRealm(userConfigFile, hashFunc string) (*FileRealm, error) {
 	realm := &FileRealm{}
 	err := gcfg.ReadFileInto(&realm.Config, userConfigFile)
 	if err != nil {
 		return nil, err
 	}
+	hashFunc = strings.ToLower(hashFunc)
+	switch hashFunc {
+	case "bcrypt":
+		realm.passwordVerifier = &bcryptPasswordVerifier{}
+	default:
+		hashIds := map[string]crypto.Hash{
+			"md5": crypto.MD5,
+			"sha1": crypto.SHA1,
+			"sha224":   crypto.SHA224,
+			"sha256": crypto.SHA256,
+			"sha512": crypto.SHA512,
+			"sha512_224": crypto.SHA512_224,
+			"sha512_256": crypto.SHA512_256,
+		}
+		hashId,ok := hashIds[hashFunc]
+		if !ok {
+			return nil, errors.New(fmt.Sprintf("Invalid Hash function %s", hashFunc))
+		}
+		realm.passwordVerifier = &cryptoPasswordVerifier{crypto.Hash(hashId)}
+	}
 	return realm, nil
 }
+
 
 func (r *FileRealm) Authenticate(username, password string) (*User, error) {
 	if username == "" {
@@ -36,7 +89,7 @@ func (r *FileRealm) Authenticate(username, password string) (*User, error) {
 	if !ok {
 		return nil, nil
 	}
-	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
+	if err := r.passwordVerifier.compareHashAndPassword(user.Password, password); err != nil {
 		return nil, err
 	}
 	//if user.Password != password {

--- a/security/file_realm_test.go
+++ b/security/file_realm_test.go
@@ -1,0 +1,76 @@
+package security
+
+import (
+	"testing"
+)
+func TestFileRealm_User(t *testing.T) {
+	var realm Realm
+	var err error
+	var user *User
+	realm, err = NewFileRealm("_test/user.cfg")
+	if err!=nil {
+		t.Error("Invalid user config file")
+	}
+	user, err = realm.Authenticate("user", "user")
+	if err != nil || user == nil {
+		t.Error("User should be authenticated")
+	}
+
+	if !user.IsAuthorized("GET", "/some/path") {
+		t.Error("User should be autorized to GET /some/path")
+	}
+	if user.IsAuthorized("DELETE", "/some/path") {
+		t.Error("User shouldn't be autorized to DELETE /some/path")
+	}
+}
+
+func TestFileRealm_Admin(t *testing.T) {
+	var realm Realm
+	var err error
+	var user *User
+	realm, err = NewFileRealm("_test/user.cfg")
+	if err!=nil {
+		t.Error("Invalid user config file %s", err)
+	}
+
+	user, err = realm.Authenticate("admin", "admin");
+	if  err != nil {
+		t.Error("Admin authentication failed %s", err)
+	} else if user == nil {
+		t.Error("Admin should be authenticated")
+	}
+
+	if !user.IsAuthorized("GET", "/some/path") {
+		t.Error("Admin should be autorized to GET /some/path")
+	}
+	if !user.IsAuthorized("DELETE", "/some/path") {
+		t.Error("Admin should be autorized to DELETE /some/path")
+	}
+}
+
+func TestFileRealmg_Anonymous(t *testing.T) {
+	var realm Realm
+	var err error
+	var user *User
+	realm, err = NewFileRealm("_test/user.cfg")
+	if err!=nil {
+		t.Error("Invalid user config file")
+	}
+
+	if user, err = realm.Authenticate("", ""); err != nil && user != nil {
+		t.Error("Anonymous should not be authenticated")
+	}
+}
+
+func TestFileRealm_InvalidPassword(t *testing.T) {
+	var realm Realm
+	var err error
+	var user *User
+	realm, err = NewFileRealm("_test/user.cfg")
+	if err!=nil {
+		t.Error("Invalid user config file")
+	}
+	if user, err = realm.Authenticate("user", "invalid"); err != nil && user != nil {
+		t.Error("Invalid password should not be authenticated")
+	}
+}

--- a/security/file_realm_test.go
+++ b/security/file_realm_test.go
@@ -48,7 +48,7 @@ func TestFileRealm_Admin(t *testing.T) {
 	}
 }
 
-func TestFileRealmg_Anonymous(t *testing.T) {
+func TestFileRealm_Anonymous(t *testing.T) {
 	var realm Realm
 	var err error
 	var user *User

--- a/security/file_realm_test.go
+++ b/security/file_realm_test.go
@@ -7,7 +7,28 @@ func TestFileRealm_User(t *testing.T) {
 	var realm Realm
 	var err error
 	var user *User
-	realm, err = NewFileRealm("_test/user.cfg")
+	realm, err = NewFileRealm("_test/user.cfg", "SHA256")
+	if err!=nil {
+		t.Error("Invalid user config file")
+	}
+	user, err = realm.Authenticate("user", "user")
+	if err != nil || user == nil {
+		t.Error("User should be authenticated")
+	}
+
+	if !user.IsAuthorized("GET", "/some/path") {
+		t.Error("User should be autorized to GET /some/path")
+	}
+	if user.IsAuthorized("DELETE", "/some/path") {
+		t.Error("User shouldn't be autorized to DELETE /some/path")
+	}
+}
+
+func TestFileRealm_UserBCrypt(t *testing.T) {
+	var realm Realm
+	var err error
+	var user *User
+	realm, err = NewFileRealm("_test/user_bcrypt.cfg", "bcrypt")
 	if err!=nil {
 		t.Error("Invalid user config file")
 	}
@@ -28,7 +49,7 @@ func TestFileRealm_Admin(t *testing.T) {
 	var realm Realm
 	var err error
 	var user *User
-	realm, err = NewFileRealm("_test/user.cfg")
+	realm, err = NewFileRealm("_test/user.cfg", "SHA256")
 	if err!=nil {
 		t.Error("Invalid user config file %s", err)
 	}
@@ -52,7 +73,7 @@ func TestFileRealm_Anonymous(t *testing.T) {
 	var realm Realm
 	var err error
 	var user *User
-	realm, err = NewFileRealm("_test/user.cfg")
+	realm, err = NewFileRealm("_test/user.cfg", "SHA256")
 	if err!=nil {
 		t.Error("Invalid user config file")
 	}
@@ -66,7 +87,7 @@ func TestFileRealm_InvalidPassword(t *testing.T) {
 	var realm Realm
 	var err error
 	var user *User
-	realm, err = NewFileRealm("_test/user.cfg")
+	realm, err = NewFileRealm("_test/user.cfg", "SHA256")
 	if err!=nil {
 		t.Error("Invalid user config file")
 	}

--- a/security/realm.go
+++ b/security/realm.go
@@ -1,0 +1,74 @@
+package security
+
+type Realm interface {
+	Authenticate(username, password string) (*User, error)
+}
+
+type User struct {
+	Name string
+	Roles []string
+}
+
+func (u *User) IsAuthorized(verb, path string) bool {
+	var authz = false
+	for _, r := range u.Roles {
+		switch r {
+		case "ADMIN":
+			authz = true
+		case "USER":
+			authz = verb == "GET" || verb == "HEAD"
+		}
+		if authz {
+			return true
+		}
+	}
+	return authz
+}
+
+type UserChecker struct {
+	Enabled bool
+	RealmName string
+	Realms []Realm
+}
+
+func NewUserChecker(enabled bool, userConfigFile, anonymousRole string) (uc *UserChecker,err error) {
+	uc = &UserChecker{Enabled: enabled}
+	if !enabled {
+		return
+	}
+	var realm Realm
+	realms := make([]Realm, 0, 2)
+	// Add File Realm
+	if userConfigFile != "" {
+		realm, err = NewFileRealm(userConfigFile)
+		if err != nil {
+			return
+		}
+		realms = append(realms, realm)
+	}
+	// Add Anonymous (should always be the last one)
+	if anonymousRole != "" {
+		realm = &AnonymousRealm{anonymousRole}
+		realms = append(realms, realm)
+	}
+	uc.Realms = realms
+	return
+}
+
+func (uc *UserChecker) Authenticate(username, password string) (user *User, err error) {
+	for _, realm := range uc.Realms {
+		user, err = realm.Authenticate(username, password)
+		if user != nil && err == nil {
+			return
+		}
+	}
+	return nil, err
+}
+
+func (uc *UserChecker) Check(username, password, method, path string) bool {
+	user, _ := uc.Authenticate(username, password)
+	if user == nil {
+		return false
+	}
+	return user.IsAuthorized(method, path)
+}

--- a/security/realm.go
+++ b/security/realm.go
@@ -1,5 +1,9 @@
 package security
 
+import (
+	log "github.com/cihub/seelog"
+)
+
 type Realm interface {
 	Authenticate(username, password string) (*User, error)
 }
@@ -31,8 +35,8 @@ type UserChecker struct {
 	Realms []Realm
 }
 
-func NewUserChecker(enabled bool, userConfigFile, anonymousRole string) (uc *UserChecker,err error) {
-	uc = &UserChecker{Enabled: enabled}
+func NewUserChecker(enabled bool, realmName, userConfigFile, anonymousRole string) (uc *UserChecker,err error) {
+	uc = &UserChecker{Enabled: enabled, RealmName: realmName}
 	if !enabled {
 		return
 	}
@@ -40,6 +44,7 @@ func NewUserChecker(enabled bool, userConfigFile, anonymousRole string) (uc *Use
 	realms := make([]Realm, 0, 2)
 	// Add File Realm
 	if userConfigFile != "" {
+		log.Infof("HTTP Basic Auth, Initializing File Realm from %s", userConfigFile)
 		realm, err = NewFileRealm(userConfigFile)
 		if err != nil {
 			return
@@ -48,6 +53,7 @@ func NewUserChecker(enabled bool, userConfigFile, anonymousRole string) (uc *Use
 	}
 	// Add Anonymous (should always be the last one)
 	if anonymousRole != "" {
+		log.Infof("HTTP Basic Auth, Initializing Anonymous Realm with role %s", anonymousRole)
 		realm = &AnonymousRealm{anonymousRole}
 		realms = append(realms, realm)
 	}

--- a/security/realm.go
+++ b/security/realm.go
@@ -72,7 +72,11 @@ func (uc *UserChecker) Authenticate(username, password string) (user *User, err 
 }
 
 func (uc *UserChecker) Check(username, password, method, path string) bool {
-	user, _ := uc.Authenticate(username, password)
+	user, err := uc.Authenticate(username, password)
+	if err != nil {
+		log.Warnf("User %s authentication failed with error %v", username, err)
+		return false
+	}
 	if user == nil {
 		return false
 	}

--- a/security/realm.go
+++ b/security/realm.go
@@ -35,7 +35,7 @@ type UserChecker struct {
 	Realms []Realm
 }
 
-func NewUserChecker(enabled bool, realmName, userConfigFile, anonymousRole string) (uc *UserChecker,err error) {
+func NewUserChecker(enabled bool, realmName, userConfigFile, userPasswordHash, anonymousRole string) (uc *UserChecker,err error) {
 	uc = &UserChecker{Enabled: enabled, RealmName: realmName}
 	if !enabled {
 		return
@@ -45,7 +45,7 @@ func NewUserChecker(enabled bool, realmName, userConfigFile, anonymousRole strin
 	// Add File Realm
 	if userConfigFile != "" {
 		log.Infof("HTTP Basic Auth, Initializing File Realm from %s", userConfigFile)
-		realm, err = NewFileRealm(userConfigFile)
+		realm, err = NewFileRealm(userConfigFile, userPasswordHash)
 		if err != nil {
 			return
 		}

--- a/security/realm_test.go
+++ b/security/realm_test.go
@@ -1,0 +1,37 @@
+package security
+
+import (
+	"testing"
+)
+
+func assertBool(t *testing.T, expected, actual bool) {
+	if expected != actual {
+		t.Errorf("Expected %v, got %v", expected, actual)
+	}
+
+}
+func TestUserChecker_AnonymousOnly(t *testing.T) {
+	uc, _ := NewUserChecker(true, "Burrow", "", "USER")
+	assertBool(t, true, uc.Check("", "", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
+	assertBool(t, false, uc.Check("user", "user", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("user", "user", "DELETE", "/some/path"))
+}
+
+func TestUserChecker_FileOnly(t *testing.T) {
+	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "")
+	assertBool(t, false, uc.Check("", "", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
+	assertBool(t, true, uc.Check("user", "user", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("user", "user", "DELETE", "/some/path"))
+	assertBool(t, false, uc.Check("user", "invalid", "GET", "/some/path"))
+}
+
+func TestUserChecker_FileAnonymous(t *testing.T) {
+	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "USER")
+	assertBool(t, true, uc.Check("", "", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
+	assertBool(t, true, uc.Check("user", "user", "GET", "/some/path"))
+	assertBool(t, false, uc.Check("user", "user", "DELETE", "/some/path"))
+	assertBool(t, false, uc.Check("user", "invalid", "GET", "/some/path"))
+}

--- a/security/realm_test.go
+++ b/security/realm_test.go
@@ -11,7 +11,7 @@ func assertBool(t *testing.T, expected, actual bool) {
 
 }
 func TestUserChecker_AnonymousOnly(t *testing.T) {
-	uc, _ := NewUserChecker(true, "Burrow", "", "USER")
+	uc, _ := NewUserChecker(true, "Burrow", "", "", "USER")
 	assertBool(t, true, uc.Check("", "", "GET", "/some/path"))
 	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
 	assertBool(t, false, uc.Check("user", "user", "GET", "/some/path"))
@@ -19,7 +19,7 @@ func TestUserChecker_AnonymousOnly(t *testing.T) {
 }
 
 func TestUserChecker_FileOnly(t *testing.T) {
-	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "")
+	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "sha256", "")
 	assertBool(t, false, uc.Check("", "", "GET", "/some/path"))
 	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
 	assertBool(t, true, uc.Check("user", "user", "GET", "/some/path"))
@@ -28,7 +28,7 @@ func TestUserChecker_FileOnly(t *testing.T) {
 }
 
 func TestUserChecker_FileAnonymous(t *testing.T) {
-	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "USER")
+	uc, _ := NewUserChecker(true, "Burrow", "_test/user.cfg", "sha256", "USER")
 	assertBool(t, true, uc.Check("", "", "GET", "/some/path"))
 	assertBool(t, false, uc.Check("", "", "DELETE", "/some/path"))
 	assertBool(t, true, uc.Check("user", "user", "GET", "/some/path"))


### PR DESCRIPTION
The `Realm` interface is in charge of authenticating a user and getting its *Roles*. There are 2 implementations at the moment: File based and Anonymous (to get default role) which can be chained. The *Realm* name is inspired by Tomcat, Elasticsearch...
The `UserChecker` is in charge of integrating HTTP Server with Realms.
The types names may be changed: suggestions are welcome.
The File Realm uses bcrypt to hash passwords on disk: I can use another hashing library/algorithm.
This pull request is related to PR #184 which brings HTTPS