### PR TITLE
Added BASIC Auth to Outbound HTTP Requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -113,6 +113,9 @@ type BurrowConfig struct {
 		PostThreshold  int      `gcfg:"post-threshold"`
 		Timeout        int      `gcfg:"timeout"`
 		Keepalive      int      `gcfg:"keepalive"`
+		AuthType      string   `gcfg:"auth-type"`
+		Username      string   `gcfg:"username"`
+		Password      string   `gcfg:"password"`
 	}
 	Slacknotifier struct {
 		Enable    bool     `gcfg:"enable"`

--- a/notifier/http_notifier.go
+++ b/notifier/http_notifier.go
@@ -35,6 +35,9 @@ type HttpNotifier struct {
 
 type HttpNotifierRequest struct {
 	Url string
+	Username     string
+	Password     string
+	AuthType     string
 	TemplateFile string
 	Method string
 	template *template.Template
@@ -188,6 +191,12 @@ func (request *HttpNotifierRequest) send(templateData interface{}, httpClient *h
 	// Send POST to HTTP endpoint
 	req, err := http.NewRequest(request.Method, request.Url, bytesToSend)
 	req.Header.Set("Content-Type", "application/json")
+
+	// Adding Authentication
+	switch request.AuthType {
+	case "basic":
+		req.SetBasicAuth(request.Username, request.Password)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/notify_center.go
+++ b/notify_center.go
@@ -219,11 +219,17 @@ func NewHttpNotifier(app *ApplicationContext) (*notifier.HttpNotifier, error) {
 
 	return &notifier.HttpNotifier{
 		RequestOpen: notifier.HttpNotifierRequest{
+			Username:     httpConfig.Username,
+			Password:     httpConfig.Password,
+			AuthType:     httpConfig.AuthType,
 			Url:          httpConfig.UrlOpen,
 			Method:       httpConfig.MethodOpen,
 			TemplateFile: httpConfig.TemplateOpen,
 		},
 		RequestClose: notifier.HttpNotifierRequest{
+			Username:     httpConfig.Username,
+			Password:     httpConfig.Password,
+			AuthType:     httpConfig.AuthType,
 			Url:          httpConfig.UrlClose,
 			Method:       httpConfig.MethodClose,
 			TemplateFile: httpConfig.TemplateClose,


### PR DESCRIPTION
Added BASIC Authorization for HTTP Notifier. This allows for calls to secure rest API.