### PR TITLE
Dockerfile updated to reduce size and be more compliant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
 FROM golang:alpine
 
-MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
+LABEL maintainer "LinkedIn Burrow https://github.com/linkedin/Burrow"
 
-RUN apk add --no-cache curl bash git ca-certificates wget \
- && update-ca-certificates \
- && curl -sSO https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm \
- && chmod +x gpm \
- && mv gpm /usr/local/bin
+ADD https://raw.githubusercontent.com/pote/gpm/v1.4.0/bin/gpm /usr/local/bin/gpm
+RUN chmod +x /usr/local/bin/gpm
 
-ADD . $GOPATH/src/github.com/linkedin/Burrow
-RUN cd $GOPATH/src/github.com/linkedin/Burrow \
- && gpm install \
- && go install \
- && mv $GOPATH/bin/Burrow $GOPATH/bin/burrow \
- && apk del git curl wget
+COPY . $GOPATH/src/github.com/linkedin/Burrow
+
+RUN apk add --no-cache --virtual .build-deps bash git \
+    && cd $GOPATH/src/github.com/linkedin/Burrow \
+    && gpm install \
+    && go install \
+    && mv $GOPATH/bin/Burrow $GOPATH/bin/burrow \
+    && apk del .build-deps
 
 ADD docker-config /etc/burrow
 


### PR DESCRIPTION
MAINTAINER has been deprecated [maintainer-deprecated](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)

Size is reduced, before 309 MB, after 286 MB and less dependencies remains.