### PR TITLE
Expose Sarama SASL Configuration Items to ClientProfile

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,5 @@
 github.com/samuel/go-zookeeper/zk   ad552be7b78b762b4a8040ffc5518bdaf5b7225d
-github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
+github.com/Shopify/sarama           c01858abb625b73a3af51d0798e4ad42c8147093
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4

--- a/config.go
+++ b/config.go
@@ -31,6 +31,10 @@ type ClientProfile struct {
 	TLSCertFilePath string  `gcfg:"tls-certfilepath"`
 	TLSKeyFilePath  string  `gcfg:"tls-keyfilepath"`
 	TLSCAFilePath   string  `gcfg:"tls-cafilepath"`
+	SASLEnable	bool	`gcfg:"sasl-enable"`
+	SASLHandshake	bool	`gcfg:"sasl-handshake"`
+	SASLUser	string	`gcfg:"sasl-username"`
+	SASLPassword	string	`gcfg:"sasl-password"`
 }
 type BurrowConfig struct {
 	General struct {
@@ -212,7 +216,8 @@ func ValidateConfig(app *ApplicationContext) error {
 	if _, ok := app.Config.Clientprofile["default"]; !ok {
 		app.Config.Clientprofile["default"] = &ClientProfile{
 			ClientID: app.Config.General.ClientID,
-			TLS:      false,
+			TLS:      	false,
+			SASLEnable:	false,
 		}
 	}
 

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -72,6 +72,12 @@ func NewKafkaClient(app *ApplicationContext, cluster string) (*KafkaClient, erro
 	}
 	clientConfig.Net.TLS.Config.InsecureSkipVerify = profile.TLSNoVerify
 
+	//Setup SASL if configured in profile
+	clientConfig.Net.SASL.Enable = profile.SASLEnable;
+	clientConfig.Net.SASL.Handshake = profile.SASLHandshake;
+	clientConfig.Net.SASL.User = profile.SASLUser
+	clientConfig.Net.SASL.Password = profile.SASLPassword
+
 	sclient, err := sarama.NewClient(app.Config.Kafka[cluster].Brokers, clientConfig)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
[Sarama PR-781](https://github.com/Shopify/sarama/pull/781) allows SASL PLAIN handshaking with Kafka. This changeset bumps the Sarama depend version to the current and adds the relevant config options to the ClientProfile object. It will default to SASL Handshaking is disabled.