### PR TITLE
Add `github.com/klauspost/crc32` to Godeps

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -3,3 +3,4 @@ github.com/Shopify/sarama           4ba9bba6adb6697bcec3841e1ecdfecf5227c3b9
 github.com/cihub/seelog             92dc4b8b540607b8187cc2f95cac200211dcd745
 gopkg.in/gcfg.v1                    0ef1a8547f99b94fac9af5377dd72febba18f37c
 github.com/pborman/uuid             ca53cad383cad2479bbba7f7a1a05797ec1386e4
+github.com/klauspost/crc32          1bab8b35b6bb565f92cbc97939610af9369f942a


### PR DESCRIPTION
This adds the `github.com/klauspost/crc32` dependency suggested in https://github.com/linkedin/Burrow/issues/222, which fixes errors for `docker-compose build`