### PR TITLE
Fix for making sure topic metadata is updated dynamically

### DIFF
--- a/offsets_store.go
+++ b/offsets_store.go
@@ -185,6 +185,7 @@ func (storage *OffsetStorage) addBrokerOffset(offset *protocol.PartitionOffset) 
 		partitionEntry.Timestamp = offset.Timestamp
 	}
 
+	clusterMap.broker[offset.Topic] = topicList
 	clusterMap.brokerLock.Unlock()
 }
 


### PR DESCRIPTION
only a 1 liner :)

The addBrokerOffset function was attempting to handle expanding partition counts in the topicList however, changes weren't reflected on the next update. So if you added more partitions to a topic they wouldn't show up. refrences https://github.com/linkedin/Burrow/issues/250