### PR TITLE
Allowing Access-Control-Allow-Origin from any domain.

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ type BurrowConfig struct {
 		Enable bool `gcfg:"server"`
 		Port   int  `gcfg:"port"`
 		Listen []string `gcfg:"listen"`
+		AccessControlAllowOrigin string `gcfg:"access-control-allow-origin"`
 	}
 	Notify struct {
 		Interval int64 `gcfg:"interval"`

--- a/config/burrow.cfg
+++ b/config/burrow.cfg
@@ -48,6 +48,8 @@ port=8000
 ; Alternatively, use listen (cannot be specified when port is)
 ; listen=host:port
 ; listen=host2:port2
+; For alternative Access Control, set this to the appropriate header. For example, a possibly unsecure option may be
+; access-control-allow-origin=*
 
 [smtp]
 server=mailserver.example.com

--- a/http_server.go
+++ b/http_server.go
@@ -95,6 +95,8 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 
 func (ah appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
 	switch {
 	case r.Method == "GET":
 		if status, err := ah.handler(ah.app, w, r); status != 200 {

--- a/http_server.go
+++ b/http_server.go
@@ -95,7 +95,9 @@ func NewHttpServer(app *ApplicationContext) (*HttpServer, error) {
 
 func (ah appHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	if len(ah.app.Config.Httpserver.AccessControlAllowOrigin) > 0 {
+		w.Header().Set("Access-Control-Allow-Origin", ah.app.Config.Httpserver.AccessControlAllowOrigin)
+	}
 
 	switch {
 	case r.Method == "GET":


### PR DESCRIPTION
I have been developing a UI on top of Burrow that utilizes the JavaScript library, Axios. That project is deployed and hosted from a different container. This allows any request to access the API from Burrow. 

Admittedly, this could be enhanced with a runtime/startup configuration. I have intentionally left it open for now for quick development, but I am open to fixes and enhancements.