### PR TITLE
Burrow 1.0 config defaults

### DIFF
--- a/core/burrow.go
+++ b/core/burrow.go
@@ -26,7 +26,7 @@ import (
 	"github.com/linkedin/Burrow/core/protocol"
 )
 
-func NewCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
+func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
 	// This order is important - it makes sure that the things taking requests start up before things sending requests
 	return [7]protocol.Coordinator{
 		&zookeeper.Coordinator{
@@ -109,7 +109,7 @@ func Start(app *protocol.ApplicationContext, exitChannel chan os.Signal) int {
 	log := app.Logger.With(zap.String("type", "main"), zap.String("name", "burrow"))
 
 	// Set up an array of coordinators in the order they are to be loaded (and closed)
-	coordinators := NewCoordinators(app)
+	coordinators := newCoordinators(app)
 
 	// Set up two main channels to use for the evaluator and storage coordinators. This is how burrow communicates
 	// internally:

--- a/core/internal/cluster/coordinator.go
+++ b/core/internal/cluster/coordinator.go
@@ -26,7 +26,7 @@ type Coordinator struct {
 	modules map[string]protocol.Module
 }
 
-func GetModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
+func getModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
 	switch className {
 	case "kafka":
 		return &KafkaCluster{
@@ -55,7 +55,7 @@ func (bc *Coordinator) Configure() {
 	}
 	for name := range modules {
 		configRoot := "cluster." + name
-		module := GetModuleForClass(bc.App, name, viper.GetString(configRoot+".class-name"))
+		module := getModuleForClass(bc.App, name, viper.GetString(configRoot+".class-name"))
 		module.Configure(name, configRoot)
 		bc.modules[name] = module
 	}

--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -26,7 +26,7 @@ type Coordinator struct {
 	modules map[string]protocol.Module
 }
 
-func GetModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
+func getModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
 	logger := app.Logger.With(
 		zap.String("type", "module"),
 		zap.String("coordinator", "consumer"),
@@ -65,7 +65,7 @@ func (cc *Coordinator) Configure() {
 		if !viper.IsSet("cluster." + viper.GetString(configRoot+".cluster")) {
 			panic("Consumer '" + name + "' references an unknown cluster '" + viper.GetString(configRoot+".cluster") + "'")
 		}
-		module := GetModuleForClass(cc.App, name, viper.GetString(configRoot+".class-name"))
+		module := getModuleForClass(cc.App, name, viper.GetString(configRoot+".class-name"))
 		module.Configure(name, configRoot)
 		cc.modules[name] = module
 	}

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -218,6 +218,7 @@ func (module *CachingEvaluator) evaluateConsumerStatus(clusterAndConsumer string
 			partitionStatus := evaluatePartitionStatus(partition)
 			partitionStatus.Topic = topic
 			partitionStatus.Partition = int32(partitionId)
+			partitionStatus.Owner = partition.Owner
 
 			if partitionStatus.Status > status.Status {
 				// If the partition status is greater than StatusError, we just mark it as StatusError

--- a/core/internal/evaluator/coordinator.go
+++ b/core/internal/evaluator/coordinator.go
@@ -57,11 +57,20 @@ func (ec *Coordinator) Configure() {
 	ec.quitChannel = make(chan struct{})
 	ec.modules = make(map[string]protocol.Module)
 
-	// Create all configured evaluator modules, add to list of evaluators
 	modules := viper.GetStringMap("evaluator")
-	if len(modules) != 1 {
+	switch len(modules) {
+	case 0:
+		// Create a default module
+		viper.Set("evaluator.default.class-name", "caching")
+		modules = viper.GetStringMap("evaluator")
+	case 1:
+		// Have one module. Just continue
+		break
+	default:
 		panic("Only one evaluator module must be configured")
 	}
+
+	// Create all configured evaluator modules, add to list of evaluators
 	for name := range modules {
 		configRoot := "evaluator." + name
 		module := GetModuleForClass(ec.App, name, viper.GetString(configRoot+".class-name"))

--- a/core/internal/evaluator/coordinator.go
+++ b/core/internal/evaluator/coordinator.go
@@ -34,7 +34,7 @@ type Coordinator struct {
 	modules     map[string]protocol.Module
 }
 
-func GetModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
+func getModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) protocol.Module {
 	switch className {
 	case "caching":
 		return &CachingEvaluator{
@@ -73,7 +73,7 @@ func (ec *Coordinator) Configure() {
 	// Create all configured evaluator modules, add to list of evaluators
 	for name := range modules {
 		configRoot := "evaluator." + name
-		module := GetModuleForClass(ec.App, name, viper.GetString(configRoot+".class-name"))
+		module := getModuleForClass(ec.App, name, viper.GetString(configRoot+".class-name"))
 		module.Configure(name, configRoot)
 		ec.modules[name] = module
 	}

--- a/core/internal/evaluator/coordinator_test.go
+++ b/core/internal/evaluator/coordinator_test.go
@@ -55,7 +55,8 @@ func TestCoordinator_Configure_NoModules(t *testing.T) {
 	viper.Set("cluster.test.class-name", "kafka")
 	viper.Set("cluster.test.servers", []string{"broker1.example.com:1234"})
 
-	assert.Panics(t, coordinator.Configure, "Expected panic")
+	coordinator.Configure()
+	assert.Lenf(t, coordinator.modules, 1, "Expected 1 module configured, not %v", len(coordinator.modules))
 }
 
 func TestCoordinator_Configure_TwoModules(t *testing.T) {

--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -47,6 +47,7 @@ func (hc *Coordinator) Configure() {
 	servers := viper.GetStringMap("httpserver")
 	if len(servers) == 0 {
 		viper.Set("httpserver.default.address", ":0")
+		servers = viper.GetStringMap("httpserver")
 	}
 
 	// Validate provided HTTP server configs

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -68,7 +68,7 @@ type Coordinator struct {
 	clusterLock *sync.RWMutex
 }
 
-func GetModuleForClass(app *protocol.ApplicationContext,
+func getModuleForClass(app *protocol.ApplicationContext,
 	moduleName string,
 	className string,
 	groupWhitelist *regexp.Regexp,
@@ -189,7 +189,7 @@ func (nc *Coordinator) Configure() {
 			templateClose = tmpl.Templates()[0]
 		}
 
-		module := GetModuleForClass(nc.App, name, viper.GetString(configRoot+".class-name"), groupWhitelist, extras, templateOpen, templateClose)
+		module := getModuleForClass(nc.App, name, viper.GetString(configRoot+".class-name"), groupWhitelist, extras, templateOpen, templateClose)
 		module.Configure(name, configRoot)
 		nc.modules[name] = module
 

--- a/core/internal/storage/coordinator.go
+++ b/core/internal/storage/coordinator.go
@@ -50,7 +50,7 @@ type Coordinator struct {
 	running     sync.WaitGroup
 }
 
-func GetModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) Module {
+func getModuleForClass(app *protocol.ApplicationContext, moduleName string, className string) Module {
 	switch className {
 	case "inmemory":
 		return &InMemoryStorage{
@@ -89,7 +89,7 @@ func (sc *Coordinator) Configure() {
 	// Create all configured storage modules, add to list of storage
 	for name := range modules {
 		configRoot := "storage." + name
-		module := GetModuleForClass(sc.App, name, viper.GetString(configRoot+".class-name"))
+		module := getModuleForClass(sc.App, name, viper.GetString(configRoot+".class-name"))
 		module.Configure(name, configRoot)
 		sc.modules[name] = module
 	}

--- a/core/internal/storage/coordinator.go
+++ b/core/internal/storage/coordinator.go
@@ -73,11 +73,20 @@ func (sc *Coordinator) Configure() {
 	sc.modules = make(map[string]protocol.Module)
 	sc.running = sync.WaitGroup{}
 
-	// Create all configured storage modules, add to list of storage
 	modules := viper.GetStringMap("storage")
-	if len(modules) != 1 {
+	switch len(modules) {
+	case 0:
+		// Create a default module
+		viper.Set("storage.default.class-name", "inmemory")
+		modules = viper.GetStringMap("storage")
+	case 1:
+		// Have one module. Just continue
+		break
+	default:
 		panic("Only one storage module must be configured")
 	}
+
+	// Create all configured storage modules, add to list of storage
 	for name := range modules {
 		configRoot := "storage." + name
 		module := GetModuleForClass(sc.App, name, viper.GetString(configRoot+".class-name"))

--- a/core/internal/storage/coordinator_test.go
+++ b/core/internal/storage/coordinator_test.go
@@ -53,7 +53,9 @@ func TestCoordinator_Configure_NoModules(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	viper.Reset()
 
-	assert.Panics(t, coordinator.Configure, "Expected panic")
+	coordinator.Configure()
+
+	assert.Lenf(t, coordinator.modules, 1, "Expected 1 module configured, not %v", len(coordinator.modules))
 }
 
 func TestCoordinator_Configure_TwoModules(t *testing.T) {

--- a/core/logger.go
+++ b/core/logger.go
@@ -23,16 +23,9 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
-
-	"github.com/linkedin/Burrow/core/internal/helpers"
 )
 
 func CheckAndCreatePidFile(filename string) bool {
-	if !helpers.ValidateFilename(filename) {
-		fmt.Fprintln(os.Stderr, "PID filename is invalid")
-		return false
-	}
-
 	// Check if the PID file exists
 	if _, err := os.Stat(filename); !os.IsNotExist(err) {
 		// The file exists, so read it and check if the PID specified is running

--- a/core/protocol/evaluator.go
+++ b/core/protocol/evaluator.go
@@ -22,6 +22,7 @@ type EvaluatorRequest struct {
 type PartitionStatus struct {
 	Topic      string          `json:"topic"`
 	Partition  int32           `json:"partition"`
+	Owner      string          `json:"owner"`
 	Status     StatusConstant  `json:"status"`
 	Start      *ConsumerOffset `json:"start"`
 	End        *ConsumerOffset `json:"end"`

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -19,11 +19,11 @@ import (
 
 type ApplicationContext struct {
 	// These fields need to be populated before Start is called
-	ConfigurationValid bool
 	Logger             *zap.Logger
 	LogLevel           *zap.AtomicLevel
 
 	// These fields will be created by Start after it is called
+	ConfigurationValid bool
 	Zookeeper          ZookeeperClient
 	ZookeeperRoot      string
 	ZookeeperConnected bool


### PR DESCRIPTION
There's no need to force the storage and evaluator module configurations to be present in config if we're using the defaults. If none are specified, configure the default values.