### PR TITLE
Burrow 1.0 group blacklist

### DIFF
--- a/core/burrow.go
+++ b/core/burrow.go
@@ -43,6 +43,20 @@ func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
 				zap.String("name", "storage"),
 			),
 		},
+		&evaluator.Coordinator{
+			App: app,
+			Log: app.Logger.With(
+				zap.String("type", "coordinator"),
+				zap.String("name", "evaluator"),
+			),
+		},
+		&httpserver.Coordinator{
+			App: app,
+			Log: app.Logger.With(
+				zap.String("type", "coordinator"),
+				zap.String("name", "httpserver"),
+			),
+		},
 		&cluster.Coordinator{
 			App: app,
 			Log: app.Logger.With(
@@ -57,25 +71,11 @@ func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
 				zap.String("name", "consumer"),
 			),
 		},
-		&evaluator.Coordinator{
-			App: app,
-			Log: app.Logger.With(
-				zap.String("type", "coordinator"),
-				zap.String("name", "evaluator"),
-			),
-		},
 		&notifier.Coordinator{
 			App: app,
 			Log: app.Logger.With(
 				zap.String("type", "coordinator"),
 				zap.String("name", "notifier"),
-			),
-		},
-		&httpserver.Coordinator{
-			App: app,
-			Log: app.Logger.With(
-				zap.String("type", "coordinator"),
-				zap.String("name", "httpserver"),
 			),
 		},
 	}

--- a/core/internal/cluster/coordinator.go
+++ b/core/internal/cluster/coordinator.go
@@ -50,9 +50,6 @@ func (bc *Coordinator) Configure() {
 
 	// Create all configured cluster modules, add to list of clusters
 	modules := viper.GetStringMap("cluster")
-	if len(modules) == 0 {
-		panic("At least one cluster module must be configured")
-	}
 	for name := range modules {
 		configRoot := "cluster." + name
 		module := getModuleForClass(bc.App, name, viper.GetString(configRoot+".class-name"))

--- a/core/internal/cluster/coordinator_test.go
+++ b/core/internal/cluster/coordinator_test.go
@@ -49,13 +49,6 @@ func TestCoordinator_Configure(t *testing.T) {
 	assert.Lenf(t, coordinator.modules, 1, "Expected 1 module configured, not %v", len(coordinator.modules))
 }
 
-func TestCoordinator_Configure_NoModules(t *testing.T) {
-	coordinator := fixtureCoordinator()
-	viper.Reset()
-
-	assert.Panics(t, coordinator.Configure, "Expected panic")
-}
-
 func TestCoordinator_Configure_TwoModules(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	viper.Set("cluster.anothertest.class-name", "kafka")

--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -57,9 +57,6 @@ func (cc *Coordinator) Configure() {
 
 	// Create all configured cluster modules, add to list of clusters
 	modules := viper.GetStringMap("consumer")
-	if len(modules) == 0 {
-		panic("At least one consumer module must be configured")
-	}
 	for name := range modules {
 		configRoot := "consumer." + name
 		if !viper.IsSet("cluster." + viper.GetString(configRoot+".cluster")) {

--- a/core/internal/consumer/coordinator_test.go
+++ b/core/internal/consumer/coordinator_test.go
@@ -52,13 +52,6 @@ func TestCoordinator_Configure(t *testing.T) {
 	assert.Lenf(t, coordinator.modules, 1, "Expected 1 module configured, not %v", len(coordinator.modules))
 }
 
-func TestCoordinator_Configure_NoModules(t *testing.T) {
-	coordinator := fixtureCoordinator()
-	viper.Reset()
-
-	assert.Panics(t, coordinator.Configure, "Expected panic")
-}
-
 func TestCoordinator_Configure_BadCluster(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	viper.Set("consumer.test.cluster", "nocluster")

--- a/core/internal/helpers/coordinators.go
+++ b/core/internal/helpers/coordinators.go
@@ -62,6 +62,10 @@ func (m *MockModule) GetGroupWhitelist() *regexp.Regexp {
 	args := m.Called()
 	return args.Get(0).(*regexp.Regexp)
 }
+func (m *MockModule) GetGroupBlacklist() *regexp.Regexp {
+	args := m.Called()
+	return args.Get(0).(*regexp.Regexp)
+}
 func (m *MockModule) GetLogger() *zap.Logger {
 	args := m.Called()
 	return args.Get(0).(*zap.Logger)

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -583,6 +583,7 @@ func TestCoordinator_checkAndSendResponseToModules(t *testing.T) {
 		coordinator.modules["test"] = mockModule
 		mockModule.On("GetName").Return("test")
 		mockModule.On("GetGroupWhitelist").Return((*regexp.Regexp)(nil))
+		mockModule.On("GetGroupBlacklist").Return((*regexp.Regexp)(nil))
 		mockModule.On("AcceptConsumerGroup", response).Return(true)
 		if testSet.ExpectSend {
 			mockModule.On("Notify", response, mock.MatchedBy(func(s string) bool { return true }), mock.MatchedBy(func(t time.Time) bool { return true }), testSet.ExpectClose).Return()

--- a/core/internal/notifier/email.go
+++ b/core/internal/notifier/email.go
@@ -34,6 +34,7 @@ type EmailNotifier struct {
 	name           string
 	threshold      int
 	groupWhitelist *regexp.Regexp
+	groupBlacklist *regexp.Regexp
 	extras         map[string]string
 	templateOpen   *template.Template
 	templateClose  *template.Template
@@ -101,6 +102,10 @@ func (module *EmailNotifier) GetName() string {
 
 func (module *EmailNotifier) GetGroupWhitelist() *regexp.Regexp {
 	return module.groupWhitelist
+}
+
+func (module *EmailNotifier) GetGroupBlacklist() *regexp.Regexp {
+	return module.groupBlacklist
 }
 
 func (module *EmailNotifier) GetLogger() *zap.Logger {

--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -33,6 +33,7 @@ type HttpNotifier struct {
 	name           string
 	threshold      int
 	groupWhitelist *regexp.Regexp
+	groupBlacklist *regexp.Regexp
 	extras         map[string]string
 	urlOpen        string
 	urlClose       string
@@ -100,6 +101,10 @@ func (module *HttpNotifier) GetName() string {
 
 func (module *HttpNotifier) GetGroupWhitelist() *regexp.Regexp {
 	return module.groupWhitelist
+}
+
+func (module *HttpNotifier) GetGroupBlacklist() *regexp.Regexp {
+	return module.groupBlacklist
 }
 
 func (module *HttpNotifier) GetLogger() *zap.Logger {

--- a/core/internal/notifier/null.go
+++ b/core/internal/notifier/null.go
@@ -29,6 +29,7 @@ type NullNotifier struct {
 	name           string
 	threshold      int
 	groupWhitelist *regexp.Regexp
+	groupBlacklist *regexp.Regexp
 	extras         map[string]string
 	templateOpen   *template.Template
 	templateClose  *template.Template
@@ -61,6 +62,10 @@ func (module *NullNotifier) GetName() string {
 
 func (module *NullNotifier) GetGroupWhitelist() *regexp.Regexp {
 	return module.groupWhitelist
+}
+
+func (module *NullNotifier) GetGroupBlacklist() *regexp.Regexp {
+	return module.groupBlacklist
 }
 
 func (module *NullNotifier) GetLogger() *zap.Logger {

--- a/core/internal/notifier/slack.go
+++ b/core/internal/notifier/slack.go
@@ -35,6 +35,7 @@ type SlackNotifier struct {
 	name           string
 	threshold      int
 	groupWhitelist *regexp.Regexp
+	groupBlacklist *regexp.Regexp
 	extras         map[string]string
 	templateOpen   *template.Template
 	templateClose  *template.Template
@@ -104,6 +105,10 @@ func (module *SlackNotifier) GetName() string {
 
 func (module *SlackNotifier) GetGroupWhitelist() *regexp.Regexp {
 	return module.groupWhitelist
+}
+
+func (module *SlackNotifier) GetGroupBlacklist() *regexp.Regexp {
+	return module.groupBlacklist
 }
 
 func (module *SlackNotifier) GetLogger() *zap.Logger {

--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -655,7 +655,7 @@ func (module *InMemoryStorage) fetchConsumer(request *protocol.StorageRequest, r
 		clusterMap.consumerLock.RUnlock()
 
 		clusterMap.consumerLock.Lock()
-		requestLogger.Info("purge expired consumer", zap.Int64("last_commit", consumerMap.lastCommit))
+		requestLogger.Debug("purge expired consumer", zap.Int64("last_commit", consumerMap.lastCommit))
 		delete(clusterMap.consumer, request.Group)
 		clusterMap.consumerLock.Unlock()
 		return


### PR DESCRIPTION
Golang does not support lookahead/lookbehind in regular expressions. This means that it's not possible (in any reasonable manner) to turn a group blacklist into a whitelist. To work with this, we need to have a blacklist and a whitelist together.

This updates the consumer and the notifier modules to have both whitelist and blacklist configs. There's a couple minor unrelated changes as well.