### PR TITLE
Burrow 1.0 - Fix notifier concurrent map access

### DIFF
--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -538,6 +538,7 @@ func TestCoordinator_checkAndSendResponseToModules(t *testing.T) {
 	coordinator.modules = make(map[string]protocol.Module)
 	coordinator.clusters = make(map[string]*ClusterGroups)
 	coordinator.notifyModuleFunc = coordinator.notifyModule
+	coordinator.clusterLock = &sync.RWMutex{}
 
 	// A test cluster and group to send notification for (so the func can check/set last time)
 	coordinator.clusters["testcluster"] = &ClusterGroups{


### PR DESCRIPTION
We need to assure that we always have a lock for the clusters map when reading it