### PR TITLE
Burrow 1.0 - No negative lag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,10 +38,22 @@
   version = "v1.0.2"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "629574ca2a5df945712d3079857300b5e4da0236"
+  version = "v1.4.2"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/snappy"
   packages = ["."]
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/hashicorp/hcl"
+  packages = [".","hcl/ast","hcl/parser","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
   branch = "master"
@@ -56,10 +68,28 @@
   version = "v1.4.7"
 
 [[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "be5ece7dd465ab0765a9682137865547526d1dfb"
+  version = "v1.7.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/mapstructure"
+  packages = ["."]
+  revision = "06020f85339e21b2478f756a78e295255ffa4d6a"
+
+[[projects]]
   name = "github.com/pborman/uuid"
   packages = ["."]
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
+
+[[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "16398bac157da96aa88f98a2df640c7f32af1da2"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/pierrec/lz4"
@@ -92,6 +122,36 @@
   revision = "e6b59f6144beb8570562539c1898a0b1fea34b41"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [".","mem"]
+  revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "acbeb36b902d72a7a4c18e8f3241075e7ab763e4"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "12bd96e66386c1960ab0f74ced1362f66f552f7b"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "25b30aa063fc18e48662b86996252eabdcf2f0c7"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/stretchr/objx"
   packages = ["."]
@@ -122,10 +182,16 @@
   version = "v1.7.1"
 
 [[projects]]
-  name = "gopkg.in/gcfg.v1"
-  packages = [".","scanner","token","types"]
-  revision = "27e4946190b4a327b539185f2b5b1f7c84730728"
-  version = "v1.2.0"
+  branch = "master"
+  name = "golang.org/x/sys"
+  packages = ["unix"]
+  revision = "bf42f188b9bc6f2cf5b8ee5a912ef1aedd0eba4c"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/text"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
   name = "gopkg.in/natefinch/lumberjack.v2"
@@ -134,14 +200,14 @@
   version = "v2.1"
 
 [[projects]]
-  name = "gopkg.in/warnings.v0"
+  branch = "v2"
+  name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "8a331561fe74dadba6edfc59f3be66c22c3b065d"
-  version = "v0.1.1"
+  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "60a9f3bc70db0e45fc3db96bea379d7e33e5114abab466ae34cf7dda5184cfe1"
+  inputs-digest = "51d6f46f5180578e74a4aa1a4fc2fa0703beca5d93d57afcd94d614900f27bbd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -206,7 +206,7 @@ func (module *CachingEvaluator) evaluateConsumerStatus(clusterAndConsumer string
 	for _, partitions := range topics {
 		for _, partition := range partitions {
 			status.TotalPartitions += 1
-			status.TotalLag += uint64(partition.CurrentLag)
+			status.TotalLag += partition.CurrentLag
 		}
 	}
 	status.Partitions = make([]*protocol.PartitionStatus, status.TotalPartitions)

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -293,7 +293,7 @@ func evaluatePartitionStatus(partition *protocol.ConsumerPartition) *protocol.Pa
 	return status
 }
 
-func calculatePartitionStatus(offsets []*protocol.ConsumerOffset, currentLag int64, timeNow int64) protocol.StatusConstant {
+func calculatePartitionStatus(offsets []*protocol.ConsumerOffset, currentLag uint64, timeNow int64) protocol.StatusConstant {
 	// First check if the lag was zero at any point, and skip the rest of the checks if this is true
 	if (currentLag > 0) && isLagAlwaysNotZero(offsets) {
 		// Check for errors, in order of severity starting with the worst. If any check comes back true, skip the rest

--- a/core/internal/evaluator/caching_test.go
+++ b/core/internal/evaluator/caching_test.go
@@ -172,7 +172,7 @@ func TestCachingEvaluator_SingleRequest_Incomplete(t *testing.T) {
 
 type testset struct {
 	offsets                 []*protocol.ConsumerOffset
-	currentLag              int64
+	currentLag              uint64
 	timeNow                 int64
 	isLagAlwaysNotZero      bool
 	checkIfOffsetsRewind    bool

--- a/core/internal/httpserver/kafka_test.go
+++ b/core/internal/httpserver/kafka_test.go
@@ -302,11 +302,11 @@ func TestHttpServer_handleConsumerDetail(t *testing.T) {
 	assert.True(t, ok, "Expected topic name to be testtopic")
 	assert.Lenf(t, topic, 1, "Expected topic to contain exactly one partition, not %v", len(topic))
 	assert.Equalf(t, "somehost", topic[0].Owner, "Expected partition Owner to be somehost, not %v", topic[0].Owner)
-	assert.Equalf(t, int64(2345), topic[0].CurrentLag, "Expected partition CurrentLag to be 2345, not %v", topic[0].CurrentLag)
+	assert.Equalf(t, uint64(2345), topic[0].CurrentLag, "Expected partition CurrentLag to be 2345, not %v", topic[0].CurrentLag)
 	assert.Lenf(t, topic[0].Offsets, 1, "Expected partition to have exactly one offset, not %v", topic[0].Offsets)
 	assert.Equalf(t, int64(9837458), topic[0].Offsets[0].Offset, "Expected Offset to be 9837458, not %v", topic[0].Offsets[0].Offset)
 	assert.Equalf(t, int64(12837487), topic[0].Offsets[0].Timestamp, "Expected Timestamp to be 12837487, not %v", topic[0].Offsets[0].Timestamp)
-	assert.Equalf(t, int64(2355), topic[0].Offsets[0].Lag, "Expected Lag to be 2355, not %v", topic[0].Offsets[0].Lag)
+	assert.Equalf(t, uint64(2355), topic[0].Offsets[0].Lag, "Expected Lag to be 2355, not %v", topic[0].Offsets[0].Lag)
 
 	// Call again for a 404
 	req, err = http.NewRequest("GET", "/v3/kafka/nocluster/consumer/testgroup", nil)

--- a/core/internal/notifier/helpers.go
+++ b/core/internal/notifier/helpers.go
@@ -104,7 +104,7 @@ func templateDivide(a, b int) int {
 	return a / b
 }
 
-func maxLagHelper(a *protocol.PartitionStatus) int64 {
+func maxLagHelper(a *protocol.PartitionStatus) uint64 {
 	if a == nil {
 		return 0
 	} else {

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -271,7 +271,7 @@ func TestInMemoryStorage_addConsumerOffset(t *testing.T) {
 		offset := r.Value.(*protocol.ConsumerOffset)
 		offsetValue := int64(1100 + (i * 100))
 		timestampValue := startTime + 10000 + int64(i*10000)
-		lagValue := int64(4321) - offsetValue
+		lagValue := uint64(int64(4321) - offsetValue)
 
 		assert.Equalf(t, offsetValue, offset.Offset, "Expected offset at position %v to be %v, got %v", i, offsetValue, offset.Offset)
 		assert.Equalf(t, timestampValue, offset.Timestamp, "Expected timestamp at position %v to be %v, got %v", i, timestampValue, offset.Timestamp)
@@ -354,7 +354,7 @@ func TestInMemoryStorage_addConsumerOffset_MinDistance(t *testing.T) {
 			// The last offset in the ring is the one that got the min-distance update
 			offsetValue = 2000
 		}
-		lagValue := int64(4321) - offsetValue
+		lagValue := uint64(int64(4321) - offsetValue)
 
 		assert.Equalf(t, offsetValue, offset.Offset, "Expected offset at position %v to be %v, got %v", i, offsetValue, offset.Offset)
 		assert.Equalf(t, timestampValue, offset.Timestamp, "Expected timestamp at position %v to be %v, got %v", i, timestampValue, offset.Timestamp)
@@ -705,7 +705,7 @@ func TestInMemoryStorage_fetchConsumer(t *testing.T) {
 	_, ok := val["testtopic"]
 	assert.True(t, ok, "Expected response to contain topic testtopic")
 	assert.Len(t, val["testtopic"], 1, "One partition for topic not returned")
-	assert.Equalf(t, int64(2421), val["testtopic"][0].CurrentLag, "Expected current lag to be 2421, not %v", val["testtopic"][0].CurrentLag)
+	assert.Equalf(t, uint64(2421), val["testtopic"][0].CurrentLag, "Expected current lag to be 2421, not %v", val["testtopic"][0].CurrentLag)
 	assert.Equalf(t, "testhost.example.com", val["testtopic"][0].Owner, "Expected owner to be testhost.example.com, not %v", val["testtopic"][0].Owner)
 
 	offsets := val["testtopic"][0].Offsets
@@ -715,7 +715,7 @@ func TestInMemoryStorage_fetchConsumer(t *testing.T) {
 
 		offsetValue := int64(1000 + (i * 100))
 		timestampValue := startTime + int64(i*10000)
-		lagValue := int64(4321) - offsetValue
+		lagValue := uint64(int64(4321) - offsetValue)
 
 		assert.Equalf(t, offsetValue, offsets[i].Offset, "Expected offset at position %v to be %v, got %v", i, offsetValue, offsets[i].Offset)
 		assert.Equalf(t, timestampValue, offsets[i].Timestamp, "Expected timestamp at position %v to be %v, got %v", i, timestampValue, offsets[i].Timestamp)

--- a/core/protocol/evaluator.go
+++ b/core/protocol/evaluator.go
@@ -26,7 +26,7 @@ type PartitionStatus struct {
 	Status     StatusConstant  `json:"status"`
 	Start      *ConsumerOffset `json:"start"`
 	End        *ConsumerOffset `json:"end"`
-	CurrentLag int64           `json:"current_lag"`
+	CurrentLag uint64          `json:"current_lag"`
 	Complete   float32         `json:"complete"`
 }
 

--- a/core/protocol/storage.go
+++ b/core/protocol/storage.go
@@ -73,13 +73,13 @@ type StorageRequest struct {
 type ConsumerPartition struct {
 	Offsets    []*ConsumerOffset `json:"offsets"`
 	Owner      string            `json:"owner"`
-	CurrentLag int64             `json:"current-lag"`
+	CurrentLag uint64            `json:"current-lag"`
 }
 
 type ConsumerOffset struct {
-	Offset    int64 `json:"offset"`
-	Timestamp int64 `json:"timestamp"`
-	Lag       int64 `json:"lag"`
+	Offset    int64  `json:"offset"`
+	Timestamp int64  `json:"timestamp"`
+	Lag       uint64 `json:"lag"`
 }
 
 type ConsumerTopics map[string]ConsumerPartitions


### PR DESCRIPTION
Because we periodically update the broker offsets, it's possible for Burrow to calculate a negative lag value for the consumer's offset commit. It's especially prone to this when the `offset-refresh` value is larger.

This assures that when the lag is calculated, it is set as zero if it would be negative. We can also change all the lag types to uint64 so it can't happen at all (and will throw an error if it might).