### PR TITLE
Burrow 1.0 - Start notifier first

### DIFF
--- a/core/burrow.go
+++ b/core/burrow.go
@@ -57,6 +57,13 @@ func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
 				zap.String("name", "httpserver"),
 			),
 		},
+		&notifier.Coordinator{
+			App: app,
+			Log: app.Logger.With(
+				zap.String("type", "coordinator"),
+				zap.String("name", "notifier"),
+			),
+		},
 		&cluster.Coordinator{
 			App: app,
 			Log: app.Logger.With(
@@ -69,13 +76,6 @@ func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {
 			Log: app.Logger.With(
 				zap.String("type", "coordinator"),
 				zap.String("name", "consumer"),
-			),
-		},
-		&notifier.Coordinator{
-			App: app,
-			Log: app.Logger.With(
-				zap.String("type", "coordinator"),
-				zap.String("name", "notifier"),
 			),
 		},
 	}


### PR DESCRIPTION
Currently, we start the notifier last, after all the clusters and consumers have started. The thinking is that you shouldn't start sending out notifications until you're done loading. However, if there is a large number of clusters (or large clusters), starting up can take a while. This leads to a gap in notifications that is a problem in some circumstances.

It's safe to start the notifier as soon as the storage and evaluator modules are started, as those are the only dependencies. The notifier already periodically updates the cluster list, so as clusters get started it will start operating on them.