### PR TITLE
Don't need to vendor burrow package itself

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,10 +11,6 @@
   version = "2.1"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/linkedin/Burrow"
-
-[[constraint]]
   name = "github.com/pborman/uuid"
   version = "1.1.0"
 

--- a/core/burrow.go
+++ b/core/burrow.go
@@ -16,14 +16,14 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/cluster"
-	"github.com/linkedin/Burrow/core/internal/consumer"
-	"github.com/linkedin/Burrow/core/internal/evaluator"
-	"github.com/linkedin/Burrow/core/internal/httpserver"
-	"github.com/linkedin/Burrow/core/internal/notifier"
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/internal/zookeeper"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/cluster"
+	"github.com/linkedin/burrow/core/internal/consumer"
+	"github.com/linkedin/burrow/core/internal/evaluator"
+	"github.com/linkedin/burrow/core/internal/httpserver"
+	"github.com/linkedin/burrow/core/internal/notifier"
+	"github.com/linkedin/burrow/core/internal/storage"
+	"github.com/linkedin/burrow/core/internal/zookeeper"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {

--- a/core/internal/cluster/coordinator.go
+++ b/core/internal/cluster/coordinator.go
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Coordinator struct {

--- a/core/internal/cluster/coordinator_test.go
+++ b/core/internal/cluster/coordinator_test.go
@@ -13,8 +13,8 @@ package cluster
 import (
 	"testing"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"

--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -18,8 +18,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type KafkaCluster struct {

--- a/core/internal/cluster/kafka_cluster_test.go
+++ b/core/internal/cluster/kafka_cluster_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureModule() *KafkaCluster {

--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Coordinator struct {

--- a/core/internal/consumer/coordinator_test.go
+++ b/core/internal/consumer/coordinator_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -19,8 +19,8 @@ import (
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 	"github.com/spf13/viper"
 	"regexp"
 )

--- a/core/internal/consumer/kafka_client_test.go
+++ b/core/internal/consumer/kafka_client_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureModule() *KafkaClient {

--- a/core/internal/consumer/kafka_zk_client.go
+++ b/core/internal/consumer/kafka_zk_client.go
@@ -20,8 +20,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type TopicList struct {

--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -21,8 +21,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureKafkaZkModule() *KafkaZkClient {

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type CachingEvaluator struct {

--- a/core/internal/evaluator/caching_test.go
+++ b/core/internal/evaluator/caching_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/storage"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureModule() (*storage.Coordinator, *CachingEvaluator) {

--- a/core/internal/evaluator/coordinator.go
+++ b/core/internal/evaluator/coordinator.go
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Module interface {

--- a/core/internal/evaluator/coordinator_test.go
+++ b/core/internal/evaluator/coordinator_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/evaluator/fixtures.go
+++ b/core/internal/evaluator/fixtures.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/storage"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 // This file ONLY contains fixtures that are used for testing. As they can be used by other package tests, we cannot

--- a/core/internal/helpers/coordinators.go
+++ b/core/internal/helpers/coordinators.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func StartCoordinatorModules(modules map[string]protocol.Module) error {

--- a/core/internal/helpers/coordinators_test.go
+++ b/core/internal/helpers/coordinators_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func TestStartCoordinatorModules(t *testing.T) {

--- a/core/internal/helpers/storage.go
+++ b/core/internal/helpers/storage.go
@@ -13,7 +13,7 @@ package helpers
 import (
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func TimeoutSendStorageRequest(storageChannel chan *protocol.StorageRequest, request *protocol.StorageRequest, maxTime int) {

--- a/core/internal/helpers/storage_test.go
+++ b/core/internal/helpers/storage_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func TestTimeoutSendStorageRequest(t *testing.T) {

--- a/core/internal/helpers/zookeeper.go
+++ b/core/internal/helpers/zookeeper.go
@@ -13,7 +13,7 @@ package helpers
 import (
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"

--- a/core/internal/helpers/zookeeper_test.go
+++ b/core/internal/helpers/zookeeper_test.go
@@ -11,7 +11,7 @@
 package helpers
 
 import (
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )

--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -27,8 +27,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Coordinator struct {

--- a/core/internal/httpserver/coordinator_test.go
+++ b/core/internal/httpserver/coordinator_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureConfiguredCoordinator() *Coordinator {

--- a/core/internal/httpserver/kafka.go
+++ b/core/internal/httpserver/kafka.go
@@ -16,7 +16,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/spf13/viper"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func (hc *Coordinator) handleClusterList(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/core/internal/httpserver/kafka_test.go
+++ b/core/internal/httpserver/kafka_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func TestHttpServer_handleClusterList(t *testing.T) {

--- a/core/internal/httpserver/structs.go
+++ b/core/internal/httpserver/structs.go
@@ -10,7 +10,7 @@
 
 package httpserver
 
-import "github.com/linkedin/Burrow/core/protocol"
+import "github.com/linkedin/burrow/core/protocol"
 
 type LogLevelRequest struct {
 	Level string `json:"level"`

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Module interface {

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/notifier/email.go
+++ b/core/internal/notifier/email.go
@@ -22,8 +22,8 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 	"github.com/spf13/viper"
 )
 

--- a/core/internal/notifier/email_test.go
+++ b/core/internal/notifier/email_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureEmailNotifier() *EmailNotifier {

--- a/core/internal/notifier/helpers.go
+++ b/core/internal/notifier/helpers.go
@@ -15,7 +15,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 // Helper functions for templates

--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type HttpNotifier struct {

--- a/core/internal/notifier/http_test.go
+++ b/core/internal/notifier/http_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureHttpNotifier() *HttpNotifier {

--- a/core/internal/notifier/null.go
+++ b/core/internal/notifier/null.go
@@ -17,7 +17,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 // This notifier is only used for testing. It is used in place of a mock when testing the coordinator so that there is

--- a/core/internal/notifier/slack.go
+++ b/core/internal/notifier/slack.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type SlackNotifier struct {

--- a/core/internal/notifier/slack_test.go
+++ b/core/internal/notifier/slack_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureSlackNotifier() *SlackNotifier {

--- a/core/internal/storage/coordinator.go
+++ b/core/internal/storage/coordinator.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Module interface {

--- a/core/internal/storage/coordinator_test.go
+++ b/core/internal/storage/coordinator_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 	"time"
 )
 

--- a/core/internal/storage/fixtures.go
+++ b/core/internal/storage/fixtures.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 // This file ONLY contains fixtures that are used for testing. As they can be used by other package tests, we cannot

--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type InMemoryStorage struct {

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureModule(whitelist string) *InMemoryStorage {

--- a/core/internal/zookeeper/coordinator.go
+++ b/core/internal/zookeeper/coordinator.go
@@ -19,8 +19,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 type Coordinator struct {

--- a/core/internal/zookeeper/coordinator_test.go
+++ b/core/internal/zookeeper/coordinator_test.go
@@ -22,8 +22,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core/internal/helpers"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/main.go
+++ b/main.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/linkedin/Burrow/core"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/linkedin/burrow/core"
+	"github.com/linkedin/burrow/core/protocol"
 )
 
 // exitCode wraps a return value for the application


### PR DESCRIPTION
When setting up the project locally I notice the burrow package itself was included in the dependency file, which to me makes no sense. Maybe I'm mistaken but I don't see the need for it.

For the tests to pass I needed to update the import statements so burrow is import in lowercase right now.

cc @toddpalino 

```
➜  burrow git:(remove_self_dependency) ✗ go test ./...
ok  	github.com/linkedin/burrow	0.011s
?   	github.com/linkedin/burrow/core	[no test files]
ok  	github.com/linkedin/burrow/core/internal/cluster	0.128s
ok  	github.com/linkedin/burrow/core/internal/consumer	0.034s
ok  	github.com/linkedin/burrow/core/internal/evaluator	2.243s
ok  	github.com/linkedin/burrow/core/internal/helpers	2.321s
ok  	github.com/linkedin/burrow/core/internal/httpserver	0.232s
ok  	github.com/linkedin/burrow/core/internal/notifier	2.573s
ok  	github.com/linkedin/burrow/core/internal/storage	0.316s
ok  	github.com/linkedin/burrow/core/internal/zookeeper	0.117s
?   	github.com/linkedin/burrow/core/protocol	[no test files]
go test ./...  20.14s user 3.39s system 360% cpu 6.525 total
```