### PR TITLE
Adding list of consumer groups consuming from topic in REST response.

### DIFF
--- a/http_server.go
+++ b/http_server.go
@@ -169,6 +169,7 @@ type HTTPResponseTopicDetail struct {
 	Error   bool                    `json:"error"`
 	Message string                  `json:"message"`
 	Offsets []int64                 `json:"offsets"`
+	Consumers []string              `json:"consumers"`
 	Request HTTPResponseRequestInfo `json:"request"`
 }
 type HTTPResponseConsumerList struct {
@@ -391,6 +392,7 @@ func handleConsumerTopicDetail(app *ApplicationContext, w http.ResponseWriter, r
 		Error:   false,
 		Message: "consumer group topic offsets returned",
 		Offsets: result.OffsetList,
+		Consumers: result.ConsumerList,
 		Request: requestInfo,
 	})
 	if err != nil {
@@ -485,6 +487,7 @@ func handleBrokerTopicDetail(app *ApplicationContext, w http.ResponseWriter, r *
 		Error:   false,
 		Message: "broker topic offsets returned",
 		Offsets: result.OffsetList,
+		Consumers: result.ConsumerList,
 		Request: requestInfo,
 	})
 	if err != nil {


### PR DESCRIPTION
We can currently get a list of topics a consumer group is consuming from. The opposite mapping is also quite useful for clients for several use cases, where a list of consuming groups is returned for a topic.

To do this now in Burrow, a client has to first request a list of all consumers for a cluster and then query each consumer to obtain a set of all topics they're consuming. From there, a mapping can be made from topic to consumer groups. This approach incurs several requests and lots of overhead.

This mapping already exists in Burrow though. I have added it to the Topic responses so end users may see which consumer groups are consuming a topic. 