### PR TITLE
Adding new request to return consumer groups for a requested topic.

### DIFF
--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -128,6 +128,7 @@ func (hc *Coordinator) Configure() {
 	hc.router.GET("/v3/kafka/:cluster", hc.handleClusterDetail)
 	hc.router.GET("/v3/kafka/:cluster/topic", hc.handleTopicList)
 	hc.router.GET("/v3/kafka/:cluster/topic/:topic", hc.handleTopicDetail)
+	hc.router.GET("/v3/kafka/:cluster/topic/:topic/consumers", hc.handleTopicConsumerList)
 	hc.router.GET("/v3/kafka/:cluster/consumer", hc.handleConsumerList)
 	hc.router.GET("/v3/kafka/:cluster/consumer/:consumer", hc.handleConsumerDetail)
 	hc.router.GET("/v3/kafka/:cluster/consumer/:consumer/status", hc.handleConsumerStatus)

--- a/core/internal/httpserver/structs.go
+++ b/core/internal/httpserver/structs.go
@@ -77,6 +77,14 @@ type httpResponseTopicDetail struct {
 	Request httpResponseRequestInfo `json:"request"`
 }
 
+type httpResponseTopicConsumerDetail struct {
+	Error   bool                    `json:"error"`
+	Message string                  `json:"message"`
+	Consumers []string              `json:"consumers"`
+	Request httpResponseRequestInfo `json:"request"`
+}
+
+
 type httpResponseConsumerList struct {
 	Error     bool                    `json:"error"`
 	Message   string                  `json:"message"`

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -812,7 +812,7 @@ func TestInMemoryStorage_fetchConsumersForTopic(t *testing.T) {
 	assert.IsType(t, []string{}, response, "Expected response to be of type []string")
 	val := response.([]string)
 	assert.Len(t, val, 1, "One consumer not returned")
-	assertEqualf(t, val[0], "testgroup", "Expected return value to be 'testgroup', not %s", val[0])
+	assert.Equalf(t, val[0], "testgroup", "Expected return value to be 'testgroup', not %s", val[0])
 
 	_, ok := <-request.Reply
 	assert.False(t, ok, "Expected channel to be closed")
@@ -863,14 +863,14 @@ func TestInMemoryStorage_fetchConsumersForTopic_MultipleConsumers(t *testing.T) 
 	assert.False(t, ok, "Expected channel to be closed")
 }
 
-func TestInMemoryStorage_fetchConsumersForTopic_NoConsumers(t *testing.T) {
+func TestInMemoryStorage_fetchConsumersForTopic_NoConsumersForTopic(t *testing.T) {
 	startTime := (time.Now().Unix() * 1000) - 100000
 	module := startWithTestConsumerOffsets("", startTime)
 
-	request = protocol.StorageRequest{
+	request := protocol.StorageRequest{
 		RequestType: protocol.StorageFetchConsumersForTopic,
 		Cluster:     "testcluster",
-		Topic:       "testtopic",
+		Topic:       "someNonExistentTopic",
 		Reply:       make(chan interface{}),
 	}
 
@@ -890,7 +890,7 @@ func TestInMemoryStorage_fetchConsumersForTopic_BadCluster(t *testing.T) {
 	startTime := (time.Now().Unix() * 1000) - 100000
 	module := startWithTestConsumerOffsets("", startTime)
 
-	request = protocol.StorageRequest{
+	request := protocol.StorageRequest{
 		RequestType: protocol.StorageFetchConsumersForTopic,
 		Cluster:     "testcluster",
 		Topic:       "testtopic",

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -781,3 +781,128 @@ func TestInMemoryStorage_fetchConsumer_Expired(t *testing.T) {
 }
 
 // TODO: Test for clear consumer offsets, including clear for missing group
+
+
+func TestInMemoryStorage_fetchConsumersForTopic(t *testing.T) {
+	startTime := (time.Now().Unix() * 1000) - 100000
+	module := startWithTestConsumerOffsets("", startTime)
+
+	// Set the owners for the test partition
+	request := protocol.StorageRequest{
+		RequestType: protocol.StorageSetConsumerOwner,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Group:       "testgroup",
+		Partition:   0,
+		Owner:       "testhost.example.com",
+	}
+	module.addConsumerOwner(&request, module.Log)
+
+	request = protocol.StorageRequest{
+		RequestType: protocol.StorageFetchConsumersForTopic,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Reply:       make(chan interface{}),
+	}
+
+	// Starting request
+	go module.fetchConsumersForTopicList(&request, module.Log)
+	response := <-request.Reply
+
+	assert.IsType(t, []string{}, response, "Expected response to be of type []string")
+	val := response.([]string)
+	assert.Len(t, val, 1, "One consumer not returned")
+	assertEqualf(t, val[0], "testgroup", "Expected return value to be 'testgroup', not %s", val[0])
+
+	_, ok := <-request.Reply
+	assert.False(t, ok, "Expected channel to be closed")
+}
+
+func TestInMemoryStorage_fetchConsumersForTopic_MultipleConsumers(t *testing.T) {
+	startTime := (time.Now().Unix() * 1000) - 100000
+	module := startWithTestConsumerOffsets("", startTime)
+
+	// Set the owners for the test partition
+	request := protocol.StorageRequest{
+		RequestType: protocol.StorageSetConsumerOwner,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Group:       "testgroup",
+		Partition:   0,
+		Owner:       "testhost.example.com",
+	}
+	module.addConsumerOwner(&request, module.Log)
+	request = protocol.StorageRequest{
+		RequestType: protocol.StorageSetConsumerOwner,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Group:       "testgroup2",
+		Partition:   0,
+		Owner:       "testhost.example.com",
+	}
+	module.addConsumerOwner(&request, module.Log)
+
+	request = protocol.StorageRequest{
+		RequestType: protocol.StorageFetchConsumersForTopic,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Reply:       make(chan interface{}),
+	}
+
+	// Starting request
+	go module.fetchConsumersForTopicList(&request, module.Log)
+	response := <-request.Reply
+
+	assert.IsType(t, []string{}, response, "Expected response to be of type []string")
+	val := response.([]string)
+	assert.Len(t, val, 2, "Two consumer not returned")
+	assert.True(t, val[0] == "testgroup" || val[0] == "testgroup2", "Expected return value was not given. Found %s", val[0])
+	assert.True(t, val[1] == "testgroup" || val[1] == "testgroup2", "Expected return value was not given. Found %s", val[1])
+
+	_, ok := <-request.Reply
+	assert.False(t, ok, "Expected channel to be closed")
+}
+
+func TestInMemoryStorage_fetchConsumersForTopic_NoConsumers(t *testing.T) {
+	startTime := (time.Now().Unix() * 1000) - 100000
+	module := startWithTestConsumerOffsets("", startTime)
+
+	request = protocol.StorageRequest{
+		RequestType: protocol.StorageFetchConsumersForTopic,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Reply:       make(chan interface{}),
+	}
+
+	// Starting request
+	go module.fetchConsumersForTopicList(&request, module.Log)
+	response := <-request.Reply
+
+	assert.IsType(t, []string{}, response, "Expected response to be of type []string")
+	val := response.([]string)
+	assert.Len(t, val, 0, "Expected no consumers to be returned")
+
+	_, ok := <-request.Reply
+	assert.False(t, ok, "Expected channel to be closed")
+}
+
+func TestInMemoryStorage_fetchConsumersForTopic_BadCluster(t *testing.T) {
+	startTime := (time.Now().Unix() * 1000) - 100000
+	module := startWithTestConsumerOffsets("", startTime)
+
+	request = protocol.StorageRequest{
+		RequestType: protocol.StorageFetchConsumersForTopic,
+		Cluster:     "testcluster",
+		Topic:       "testtopic",
+		Reply:       make(chan interface{}),
+	}
+
+	// Starting request
+	go module.fetchConsumersForTopicList(&request, module.Log)
+	response := <-request.Reply
+
+	response, ok := <-request.Reply
+
+	assert.Nil(t, response, "Expected response to be nil")
+	assert.False(t, ok, "Expected channel to be closed")
+}

--- a/core/protocol/storage.go
+++ b/core/protocol/storage.go
@@ -58,6 +58,10 @@ const (
 	// StorageClearConsumerOwners is the request type to remove all partition owner information for a single group.
 	// Requires Cluster and Group fields
 	StorageClearConsumerOwners StorageRequestConstant = 10
+
+	// StorageFetchConsumersForTopic is the request type to obtain a list of all consumer groups consuming from a topic.
+	// Returns a []string
+	StorageFetchConsumersForTopic StorageRequestConstant = 11
 )
 
 var storageRequestStrings = [...]string{
@@ -72,6 +76,7 @@ var storageRequestStrings = [...]string{
 	"StorageFetchConsumer",
 	"StorageFetchTopic",
 	"StorageClearConsumerOwners",
+	"StorageFetchConsumersForTopic",
 }
 
 // String returns a string representation of a StorageRequestConstant for logging


### PR DESCRIPTION
Following-up on the discussion from https://github.com/linkedin/Burrow/pull/284#issuecomment-347723315

This is meant to add an interface to request the IDs of consumer groups that are consuming from a given topic.