### PR TITLE
Clean up lint/vet issues and potential races

### DIFF
--- a/core/burrow.go
+++ b/core/burrow.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Core Burrow logic.
+// Package core - Core Burrow logic.
 // The core package is where all the internal logic for Burrow is located. It provides several helpers for setting up
 // logging and application management (such as PID files), as well as the Start method that runs Burrow itself.
 //

--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Kafka consumer subsystem.
+// Package consumer - Kafka consumer subsystem.
 // The consumer subsystem is responsible for getting consumer offset information and sending that information to the
 // storage subsystem. This consumer information could be stored in a variety of places, and each module supports a
 // different type of repository.

--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/linkedin/Burrow/core/internal/helpers"
 	"github.com/linkedin/Burrow/core/protocol"
-	"sync"
 	"github.com/stretchr/testify/mock"
+	"sync"
 )
 
 func fixtureKafkaZkModule() *KafkaZkClient {

--- a/core/internal/doc.go
+++ b/core/internal/doc.go
@@ -1,4 +1,4 @@
-// Here be dragons.
+// Package internal - Here be dragons.
 // The internal package contains the bulk of Burrow's logic, including all of the coordinators and modules that have
 // been defined. This documentation is targeted at developers of Burrow modules to get more information about the
 // internal structure and how the modules fit together. It is not designed for end users, and for the most part will not

--- a/core/internal/evaluator/coordinator.go
+++ b/core/internal/evaluator/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Group evaluation subsystem.
+// Package evaluator - Group evaluation subsystem.
 // The evaluator subsystem is responsible for fetching group information from the storage subsystem and calculating the
 // group's status based on that. It responds to EvaluatorRequest objects that are send via a channel, and replies with
 // a ConsumerGroupStatus.

--- a/core/internal/helpers/coordinators.go
+++ b/core/internal/helpers/coordinators.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Common utilities.
+// Package helpers - Common utilities.
 // The helpers subsystem provides common utilities that can be used by all subsystems. This includes utilities for
 // coordinators to start and stop modules, as well as Kafka and Zookeeper client implementations. There are also a
 // number of mocks that are provided for testing purposes only, and should not be used in normal code.

--- a/core/internal/helpers/time_test.go
+++ b/core/internal/helpers/time_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+	"sync"
 )
 
 func TestPausableTicker_ImplementsTicker(t *testing.T) {
@@ -47,7 +48,10 @@ func TestPausableTicker_StartStop(t *testing.T) {
 	numEvents := 0
 	quitChan := make(chan struct{})
 	channel := ticker.GetChannel()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-channel:
@@ -62,6 +66,7 @@ func TestPausableTicker_StartStop(t *testing.T) {
 	ticker.Stop()
 	time.Sleep(50 * time.Millisecond)
 	close(quitChan)
+	wg.Wait()
 
 	assert.Equalf(t, 2, numEvents, "Expected 2 events, not %v", numEvents)
 }
@@ -73,7 +78,10 @@ func TestPausableTicker_Restart(t *testing.T) {
 	numEvents := 0
 	quitChan := make(chan struct{})
 	channel := ticker.GetChannel()
+	wg := sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			select {
 			case <-channel:
@@ -91,6 +99,7 @@ func TestPausableTicker_Restart(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	ticker.Stop()
 	close(quitChan)
+	wg.Wait()
 
 	assert.Equalf(t, 4, numEvents, "Expected 4 events, not %v", numEvents)
 }

--- a/core/internal/helpers/time_test.go
+++ b/core/internal/helpers/time_test.go
@@ -12,9 +12,9 @@ package helpers
 
 import (
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 	"time"
-	"sync"
 )
 
 func TestPausableTicker_ImplementsTicker(t *testing.T) {

--- a/core/internal/helpers/validation.go
+++ b/core/internal/helpers/validation.go
@@ -52,12 +52,13 @@ func ValidateZookeeperPath(path string) bool {
 		// Root node is OK
 		return true
 	}
+
+	nodeRegexp, _ := regexp.Compile(`^[a-zA-Z0-9_\-][a-zA-Z0-9_\-.]*$`)
 	for i, node := range parts {
 		if i == 0 {
 			continue
 		}
-		matches, _ := regexp.MatchString(`^[a-zA-Z0-9_\-][a-zA-Z0-9_\-.]*$`, node)
-		if !matches {
+		if ! nodeRegexp.MatchString(node) {
 			return false
 		}
 	}

--- a/core/internal/helpers/validation.go
+++ b/core/internal/helpers/validation.go
@@ -58,7 +58,7 @@ func ValidateZookeeperPath(path string) bool {
 		if i == 0 {
 			continue
 		}
-		if ! nodeRegexp.MatchString(node) {
+		if !nodeRegexp.MatchString(node) {
 			return false
 		}
 	}

--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// HTTP server subsystem.
+// Package httpserver - HTTP API endpoint
 // The httpserver subsystem provides an HTTP interface to Burrow that can be used to fetch information about the
 // clusters and consumers it is monitoring. More documentation on the requests and responses is provided at
 // https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint.

--- a/core/internal/httpserver/structs.go
+++ b/core/internal/httpserver/structs.go
@@ -53,7 +53,7 @@ type httpResponseClientProfile struct {
 	ClientID     string                   `json:"client-id"`
 	KafkaVersion string                   `json:"kafka-version"`
 	TLS          *httpResponseTLSProfile  `json:"tls"`
-	SASL         *httpResponseSASLProfile `json:"tls"`
+	SASL         *httpResponseSASLProfile `json:"sasl"`
 }
 
 type httpResponseClusterList struct {

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -342,8 +342,9 @@ func (nc *Coordinator) sendClusterRequest() {
 		RequestType: protocol.StorageFetchClusters,
 		Reply:       make(chan interface{}),
 	}
+
+	nc.running.Add(1)
 	go func() {
-		nc.running.Add(1)
 		defer nc.running.Done()
 		nc.processClusterList(request.Reply)
 	}()

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Status notification subsystem.
+// Package notifier - Status notification subsystem.
 // The notifier subsystem watches the status for all consumer groups and uses the configured modules to send
 // information about the status of those groups to outside systems, such as via email or calls to HTTP endpoints. The
 // message bodies are built using templates, and notifications can be sent for both active problems as well as when

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -258,6 +258,7 @@ func (nc *Coordinator) Start() error {
 
 	// The notifier coordinator is responsible for fetching group evaluations and handing them off to the individual
 	// notifier modules.
+	nc.running.Add(1)
 	go nc.responseLoop()
 
 	err := helpers.StartCoordinatorModules(nc.modules)
@@ -272,6 +273,7 @@ func (nc *Coordinator) Start() error {
 	go nc.manageEvalLoop()
 
 	// Run our main loop to watch tickers and take actions
+	nc.running.Add(1)
 	go nc.tickerLoop()
 
 	return nil
@@ -307,6 +309,7 @@ func (nc *Coordinator) manageEvalLoop() {
 
 		// We've got the lock, start the evaluation loop
 		nc.doEvaluations = true
+		nc.running.Add(1)
 		go nc.sendEvaluatorRequests()
 		nc.Log.Info("starting evaluations", zap.Error(err))
 
@@ -326,6 +329,8 @@ func (nc *Coordinator) manageEvalLoop() {
 
 // We keep this function trivial because tickers are not easy to mock/test in golang
 func (nc *Coordinator) tickerLoop() {
+	defer nc.running.Done()
+
 	for {
 		select {
 		case <-nc.groupRefresh.GetChannel():
@@ -344,15 +349,11 @@ func (nc *Coordinator) sendClusterRequest() {
 	}
 
 	nc.running.Add(1)
-	go func() {
-		defer nc.running.Done()
-		nc.processClusterList(request.Reply)
-	}()
+	go nc.processClusterList(request.Reply)
 	helpers.TimeoutSendStorageRequest(nc.App.StorageChannel, request, 1)
 }
 
 func (nc *Coordinator) sendEvaluatorRequests() {
-	nc.running.Add(1)
 	defer nc.running.Done()
 
 	for nc.doEvaluations {
@@ -386,6 +387,8 @@ func (nc *Coordinator) sendEvaluatorRequests() {
 }
 
 func (nc *Coordinator) responseLoop() {
+	defer nc.running.Done()
+
 	for {
 		select {
 		case response := <-nc.evaluatorResponse:
@@ -396,6 +399,7 @@ func (nc *Coordinator) responseLoop() {
 
 			// As long as the response is not NotFound, send it to the modules
 			if response.Status != protocol.StatusNotFound {
+				nc.running.Add(1)
 				go nc.checkAndSendResponseToModules(response)
 			}
 		case <-nc.quitChannel:
@@ -405,6 +409,8 @@ func (nc *Coordinator) responseLoop() {
 }
 
 func (nc *Coordinator) checkAndSendResponseToModules(response *protocol.ConsumerGroupStatus) {
+	defer nc.running.Done()
+
 	nc.clusterLock.RLock()
 	defer nc.clusterLock.RUnlock()
 	cluster := nc.clusters[response.Cluster]
@@ -436,6 +442,7 @@ func (nc *Coordinator) checkAndSendResponseToModules(response *protocol.Consumer
 			continue
 		}
 		if module.AcceptConsumerGroup(response) {
+			nc.running.Add(1)
 			nc.notifyModuleFunc(module, response, cgroup.Start, cgroup.ID)
 		}
 	}
@@ -448,6 +455,8 @@ func (nc *Coordinator) checkAndSendResponseToModules(response *protocol.Consumer
 }
 
 func (nc *Coordinator) processClusterList(replyChan chan interface{}) {
+	defer nc.running.Done()
+
 	response := <-replyChan
 	clusterList, _ := response.([]string)
 	requestMap := make(map[string]*protocol.StorageRequest)
@@ -480,12 +489,15 @@ func (nc *Coordinator) processClusterList(replyChan chan interface{}) {
 
 	// Fire off requests for group lists to the storage module, with goroutines to process the responses
 	for cluster, request := range requestMap {
+		nc.running.Add(1)
 		go nc.processConsumerList(cluster, request.Reply)
 		helpers.TimeoutSendStorageRequest(nc.App.StorageChannel, request, 1)
 	}
 }
 
 func (nc *Coordinator) processConsumerList(cluster string, replyChan chan interface{}) {
+	defer nc.running.Done()
+
 	response := <-replyChan
 	consumerList, _ := response.([]string)
 
@@ -514,7 +526,6 @@ func (nc *Coordinator) processConsumerList(cluster string, replyChan chan interf
 }
 
 func (nc *Coordinator) notifyModule(module Module, status *protocol.ConsumerGroupStatus, startTime time.Time, eventID string) {
-	nc.running.Add(1)
 	defer nc.running.Done()
 
 	// Note - it is assumed that a read lock is already held when calling notifyModule

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -1,0 +1,149 @@
+// +build !race
+
+/* Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package notifier
+
+import (
+	"time"
+
+	"testing"
+	"github.com/stretchr/testify/assert"
+
+
+	"github.com/linkedin/Burrow/core/internal/helpers"
+	"sync"
+)
+
+// This tests the full set of calls to send evaluator requests. It triggers the race detector because of setting
+// doEvaluations to false to end the loop.
+func TestCoordinator_sendEvaluatorRequests(t *testing.T) {
+	coordinator := fixtureCoordinator()
+	coordinator.Configure()
+
+	// A test cluster and group to send requests for
+	coordinator.clusters["testcluster"] = &clusterGroups{
+		Lock:   &sync.RWMutex{},
+		Groups: make(map[string]*consumerGroup),
+	}
+	coordinator.clusters["testcluster"].Groups["testgroup"] = &consumerGroup{
+		LastNotify: make(map[string]time.Time),
+		LastEval:   time.Now().Add(-time.Duration(coordinator.minInterval) * time.Second),
+	}
+	coordinator.clusters["testcluster2"] = &clusterGroups{
+		Lock:   &sync.RWMutex{},
+		Groups: make(map[string]*consumerGroup),
+	}
+	coordinator.clusters["testcluster2"].Groups["testgroup2"] = &consumerGroup{
+		LastNotify: make(map[string]time.Time),
+		LastEval:   time.Now().Add(-time.Duration(coordinator.minInterval) * time.Second),
+	}
+
+	coordinator.doEvaluations = true
+	coordinator.running.Add(1)
+	go coordinator.sendEvaluatorRequests()
+
+	// We expect to get 2 requests
+	for i := 0; i < 2; i++ {
+		request := <-coordinator.App.EvaluatorChannel
+		switch request.Cluster {
+		case "testcluster":
+			assert.Equalf(t, "testcluster", request.Cluster, "Expected request cluster to be testcluster, not %v", request.Cluster)
+			assert.Equalf(t, "testgroup", request.Group, "Expected request group to be testgroup, not %v", request.Group)
+			assert.False(t, request.ShowAll, "Expected ShowAll to be false")
+		case "testcluster2":
+			assert.Equalf(t, "testcluster2", request.Cluster, "Expected request cluster to be testcluster2, not %v", request.Cluster)
+			assert.Equalf(t, "testgroup2", request.Group, "Expected request group to be testgroup2, not %v", request.Group)
+			assert.False(t, request.ShowAll, "Expected ShowAll to be false")
+		default:
+			assert.Failf(t, "Received unexpected request for cluster %v, group %v", request.Cluster, request.Group)
+		}
+	}
+
+	select {
+	case <-coordinator.App.EvaluatorChannel:
+		assert.Fail(t, "Received extra request on the evaluator channel")
+	default:
+		// All is good - we didn't expect to find another request
+	}
+	coordinator.doEvaluations = false
+}
+
+// We know this will trigger the race detector, because of the way we manipulate the ZK state
+func TestCoordinator_manageEvalLoop_Start(t *testing.T) {
+	coordinator := fixtureCoordinator()
+	coordinator.Configure()
+
+	// Add mock calls for the Zookeeper client - Lock immediately returns with no error
+	mockLock := &helpers.MockZookeeperLock{}
+	mockLock.On("Lock").Return(nil)
+	mockZk := coordinator.App.Zookeeper.(*helpers.MockZookeeperClient)
+	mockZk.On("NewLock", "/burrow/notifier").Return(mockLock)
+
+	go coordinator.manageEvalLoop()
+	time.Sleep(200 * time.Millisecond)
+
+	mockLock.AssertExpectations(t)
+	mockZk.AssertExpectations(t)
+	assert.True(t, coordinator.doEvaluations, "Expected doEvaluations to be true")
+}
+
+// We know this will trigger the race detector, because of the way we manipulate the ZK state
+func TestCoordinator_manageEvalLoop_Expiration(t *testing.T) {
+	coordinator := fixtureCoordinator()
+	coordinator.Configure()
+
+	// Add mock calls for the Zookeeper client - Lock immediately returns with no error
+	mockLock := &helpers.MockZookeeperLock{}
+	mockLock.On("Lock").Return(nil)
+	mockZk := coordinator.App.Zookeeper.(*helpers.MockZookeeperClient)
+	mockZk.On("NewLock", "/burrow/notifier").Return(mockLock)
+
+	go coordinator.manageEvalLoop()
+	time.Sleep(200 * time.Millisecond)
+
+	// ZK gets disconnected and expired
+	coordinator.App.ZookeeperConnected = false
+	coordinator.App.ZookeeperExpired.Broadcast()
+	time.Sleep(300 * time.Millisecond)
+
+	mockLock.AssertExpectations(t)
+	mockZk.AssertExpectations(t)
+	assert.False(t, coordinator.doEvaluations, "Expected doEvaluations to be false")
+}
+
+// We know this will trigger the race detector, because of the way we manipulate the ZK state
+func TestCoordinator_manageEvalLoop_Reconnect(t *testing.T) {
+	coordinator := fixtureCoordinator()
+	coordinator.Configure()
+
+	// Add mock calls for the Zookeeper client - Lock immediately returns with no error
+	mockLock := &helpers.MockZookeeperLock{}
+	mockLock.On("Lock").Return(nil)
+	mockZk := coordinator.App.Zookeeper.(*helpers.MockZookeeperClient)
+	mockZk.On("NewLock", "/burrow/notifier").Return(mockLock)
+
+	go coordinator.manageEvalLoop()
+	time.Sleep(200 * time.Millisecond)
+
+	// ZK gets disconnected and expired
+	coordinator.App.ZookeeperConnected = false
+	coordinator.App.ZookeeperExpired.Broadcast()
+	time.Sleep(200 * time.Millisecond)
+
+	// ZK gets reconnected
+	coordinator.App.ZookeeperConnected = true
+	time.Sleep(300 * time.Millisecond)
+
+	mockLock.AssertExpectations(t)
+	mockZk.AssertExpectations(t)
+	assert.True(t, coordinator.doEvaluations, "Expected doEvaluations to be true")
+}

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -15,9 +15,8 @@ package notifier
 import (
 	"time"
 
-	"testing"
 	"github.com/stretchr/testify/assert"
-
+	"testing"
 
 	"github.com/linkedin/Burrow/core/internal/helpers"
 	"sync"

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -194,7 +194,6 @@ func TestCoordinator_sendClusterRequest(t *testing.T) {
 		}()
 	}()
 
-
 	coordinator.sendClusterRequest()
 	coordinator.running.Wait()
 	wg.Wait()
@@ -604,4 +603,3 @@ func TestCoordinator_ExecuteTemplate(t *testing.T) {
 	assert.Nil(t, err, "Expected no error to be returned")
 	assert.Equalf(t, "testidstring testcluster testgroup OK", bytesToSend.String(), "Unexpected, got: %v", bytesToSend.String())
 }
-

--- a/core/internal/notifier/email.go
+++ b/core/internal/notifier/email.go
@@ -38,7 +38,6 @@ type EmailNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	threshold      int
 	groupWhitelist *regexp.Regexp
 	groupBlacklist *regexp.Regexp
 	extras         map[string]string

--- a/core/internal/notifier/helpers.go
+++ b/core/internal/notifier/helpers.go
@@ -99,7 +99,6 @@ func templateCountPartitions(partitions []*protocol.PartitionStatus) map[string]
 	for _, partition := range partitions {
 		switch partition.Status {
 		case protocol.StatusOK:
-			break
 		case protocol.StatusWarning:
 			rv["warn"]++
 		case protocol.StatusStop:

--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -39,7 +39,6 @@ type HTTPNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	threshold      int
 	groupWhitelist *regexp.Regexp
 	groupBlacklist *regexp.Regexp
 	extras         map[string]string

--- a/core/internal/notifier/null.go
+++ b/core/internal/notifier/null.go
@@ -31,7 +31,6 @@ type NullNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	threshold      int
 	groupWhitelist *regexp.Regexp
 	groupBlacklist *regexp.Regexp
 	extras         map[string]string

--- a/core/internal/storage/coordinator.go
+++ b/core/internal/storage/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Data storage subsystem.
+// Package storage - Data storage subsystem.
 // The storage subsystem receives information from the cluster and consumer subsystems and serves that information out
 // to other subsystems on request.
 //

--- a/core/internal/zookeeper/coordinator.go
+++ b/core/internal/zookeeper/coordinator.go
@@ -134,24 +134,17 @@ func (zc *Coordinator) mainLoop(eventChan <-chan zk.Event) {
 	zc.running.Add(1)
 	defer zc.running.Done()
 
-	for {
-		select {
-		case event, isOpen := <-eventChan:
-			if !isOpen {
-				// All done here
-				return
-			}
-			if event.Type == zk.EventSession {
-				switch event.State {
-				case zk.StateExpired:
-					zc.Log.Error("session expired")
-					zc.App.ZookeeperConnected = false
-					zc.App.ZookeeperExpired.Broadcast()
-				case zk.StateConnected:
-					if !zc.App.ZookeeperConnected {
-						zc.Log.Info("starting session")
-						zc.App.ZookeeperConnected = true
-					}
+	for event := range eventChan {
+		if event.Type == zk.EventSession {
+			switch event.State {
+			case zk.StateExpired:
+				zc.Log.Error("session expired")
+				zc.App.ZookeeperConnected = false
+				zc.App.ZookeeperExpired.Broadcast()
+			case zk.StateConnected:
+				if !zc.App.ZookeeperConnected {
+					zc.Log.Info("starting session")
+					zc.App.ZookeeperConnected = true
 				}
 			}
 		}

--- a/core/internal/zookeeper/coordinator.go
+++ b/core/internal/zookeeper/coordinator.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Common Zookeeper subsystem.
+// Package zookeeper - Common Zookeeper subsystem.
 // The zookeeper subsystem provides a Zookeeper client that is common across all of Burrow, and can be used by other
 // subsystems to store metadata or coordinate operations between multiple Burrow instances. It is used primarily to
 // assure that only one Burrow instance is sending notifications at any time.

--- a/core/internal/zookeeper/coordinator_test.go
+++ b/core/internal/zookeeper/coordinator_test.go
@@ -118,7 +118,10 @@ func TestCoordinator_mainLoop(t *testing.T) {
 }
 
 // Example for the Coordinator docs on how to do connection state monitoring
-func ExampleCoordinator_stateMonitoring(app *protocol.ApplicationContext) {
+func ExampleCoordinator_stateMonitoring() {
+	// Ignore me - needed to make the example clean
+	app := &protocol.ApplicationContext{}
+
 	for {
 		// Wait for the Zookeeper connection to be connected
 		for !app.ZookeeperConnected {

--- a/core/internal/zookeeper/coordinator_test.go
+++ b/core/internal/zookeeper/coordinator_test.go
@@ -1,3 +1,5 @@
+// +build !race
+
 /* Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
  * 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -8,7 +8,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  */
 
-// Burrow types and interfaces.
+// Package protocol - Burrow types and interfaces.
 // The protocol module provides the definitions for most of the common Burrow types and interfaces that are used in the
 // rest of the application. The documentation here is primarily targeted at developers of Burrow modules, and not the
 // end user.

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ type exitCode struct{ Code int }
 
 func handleExit() {
 	if e := recover(); e != nil {
-		if exit, ok := e.(exitCode); ok == true {
+		if exit, ok := e.(exitCode); ok {
 			if exit.Code != 0 {
 				fmt.Fprintln(os.Stderr, "Burrow failed at", time.Now().Format("January 2, 2006 at 3:04pm (MST)"))
 			} else {


### PR DESCRIPTION
There's a number of nit-picking issues from vet/lint, as well as megacheck, that needed to be cleaned up before we start CI.

There were also a number of issues highlighted by the race detector that are now cleaned up.