### PR TITLE
Remove Burrow from dep config

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,10 +11,6 @@
   version = "2.1"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/linkedin/Burrow"
-
-[[constraint]]
   name = "github.com/pborman/uuid"
   version = "1.1.0"
 


### PR DESCRIPTION
Burrow doesn't need to depend on itself. Thanks to @niels-s for the fix.