### PR TITLE
Upgrade sarama dependency to support Kafka 0.11.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.12.0"
+  version = "1.14.0"
 
 [[constraint]]
   name = "go.uber.org/zap"

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -40,6 +40,8 @@ func parseKafkaVersion(kafkaVersion string) sarama.KafkaVersion {
 		return sarama.V0_10_1_0
 	case "", "0.10.2", "0.10.2.0":
 		return sarama.V0_10_2_0
+	case "0.11.0", "0.11.0.1", "0.11.0.2":
+		return sarama.V0_11_0_0
 	default:
 		panic("Unknown Kafka Version: " + kafkaVersion)
 	}


### PR DESCRIPTION
Burrow 0.1.1 was working just fine with Kafka 0.11.0.1, but due to the introduction of a new helper in the latest version, it now fails to start with the following error:
```
{"level":"panic","ts":1512380881.6406214,"msg":"Unknown Kafka Version: 0.11.0"}
```
Now I could probably work around it by simply specifying a lower version of Kafka than I'm actually using, but we might as well do it properly, right?

I checked sarama changes and it doesn't look like it would break anything in Burrow.