### PR TITLE
Update sarama to support Kafka 1.0.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.14.0"
+  version = "1.15.0"
 
 [[constraint]]
   name = "go.uber.org/zap"

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -42,6 +42,8 @@ func parseKafkaVersion(kafkaVersion string) sarama.KafkaVersion {
 		return sarama.V0_10_2_0
 	case "0.11.0", "0.11.0.1", "0.11.0.2":
 		return sarama.V0_11_0_0
+	case "1.0.0":
+		return sarama.V1_0_0_0
 	default:
 		panic("Unknown Kafka Version: " + kafkaVersion)
 	}


### PR DESCRIPTION
Similarly to https://github.com/linkedin/Burrow/pull/297, adds support for Kafka 1.0.0.