### PR TITLE
Fixing requests for StorageFetchConsumersForTopic

### DIFF
--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -202,7 +202,7 @@ func (module *InMemoryStorage) mainLoop() {
 
 	for r := range module.requestChannel {
 		switch r.RequestType {
-		case protocol.StorageSetBrokerOffset, protocol.StorageSetDeleteTopic, protocol.StorageFetchClusters, protocol.StorageFetchConsumers, protocol.StorageFetchTopics, protocol.StorageFetchTopic:
+		case protocol.StorageSetBrokerOffset, protocol.StorageSetDeleteTopic, protocol.StorageFetchClusters, protocol.StorageFetchConsumers, protocol.StorageFetchTopics, protocol.StorageFetchTopic, protocol.StorageFetchConsumersForTopic:
 			// Send to any worker
 			module.workers[int(rand.Int31n(int32(module.numWorkers)))] <- r
 		case protocol.StorageSetConsumerOffset, protocol.StorageSetConsumerOwner, protocol.StorageSetDeleteGroup, protocol.StorageClearConsumerOwners, protocol.StorageFetchConsumer:


### PR DESCRIPTION
Commit b0c3777553953ea6b6d524b1ec98a0ed0328dc05 implemented an API where clients could request a list of consumers for a given topic. I found after deploying this that the request would always fail.

Diving deeper into the code, it seems a request of type StorageFetchConsumersForTopic was not mapped to any workers that could respond to the request. 

Adding this to the case statement seems to fix the issue for me. 