### PR TITLE
Reject offsets that are older than the group expiration time

### DIFF
--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -326,6 +326,11 @@ func (module *InMemoryStorage) addConsumerOffset(request *protocol.StorageReques
 		return
 	}
 
+	if request.Timestamp < ((time.Now().Unix() - module.expireGroup) * 1000) {
+		requestLogger.Debug("dropped", zap.String("reason", "old offset"))
+		return
+	}
+
 	if !module.acceptConsumerGroup(request.Group) {
 		requestLogger.Debug("dropped", zap.String("reason", "group not whitelisted"))
 		return

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -293,6 +293,14 @@ func TestInMemoryStorage_addConsumerOffset_Whitelist(t *testing.T) {
 	assert.False(t, ok, "Group testgroup created when not whitelisted")
 }
 
+func TestInMemoryStorage_addConsumerOffset_TooOld(t *testing.T) {
+	module := startWithTestConsumerOffsets("testgroup", 1000000)
+
+	// All offsets for the test group should have been dropped as they are too old
+	_, ok := module.offsets["testcluster"].consumer["testgroup"]
+	assert.False(t, ok, "Group testgroup created when offsets are too old")
+}
+
 type testset struct {
 	whitelist  string
 	passGroups []string


### PR DESCRIPTION
Currently, Burrow will accept any offset for storage. Especially in the case of Zookeeper offsets, it's possible to have stale data (topics that are no longer consumed, or old offsets that have been moved over to Kafka) that will get pulled in and cause false alerts.

This PR adds a check into the storage module to reject offsets if they are older than the expire-group configuration. The reasoning is that if the offset is old enough that we would expire a group with just that offset, we shouldn't accept it at all. This should greatly reduce false alerts due to stale Zookeeper data, and it shouldn't impact current offsets at all.

This also updates the tests to support this and properly test min-distance and offset expiration.

Closes #320 
