### PR TITLE
Can't send http notifier for templateClose

### DIFF
--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/linkedin/Burrow/core/internal/helpers"
 	"github.com/linkedin/Burrow/core/protocol"
+	"path/filepath"
 )
 
 // Module defines a means of sending out notifications of consumer group status (such as email), as well as regular
@@ -213,20 +214,24 @@ func (nc *Coordinator) Configure() {
 
 		// Compile the templates
 		var templateOpen, templateClose *template.Template
-		tmpl, err := nc.templateParseFunc(viper.GetString(configRoot + ".template-open"))
+		templateOpenPath := viper.GetString(configRoot + ".template-open")
+		templateOpenFile := filepath.Base(templateOpenPath)
+		tmpl, err := nc.templateParseFunc(templateOpenPath)
 		if err != nil {
 			nc.Log.Panic("Failed to compile TemplateOpen", zap.Error(err), zap.String("module", name))
 			panic(err)
 		}
-		templateOpen = tmpl.Templates()[0]
+		templateOpen = tmpl.Lookup(templateOpenFile)
 
 		if viper.GetBool(configRoot + ".send-close") {
-			tmpl, err = nc.templateParseFunc(viper.GetString(configRoot + ".template-close"))
+			templateClosePath := viper.GetString(configRoot + ".template-close")
+			templateCloseFile := filepath.Base(templateClosePath)
+			tmpl, err = nc.templateParseFunc(templateClosePath)
 			if err != nil {
 				nc.Log.Panic("Failed to compile TemplateClose", zap.Error(err), zap.String("module", name))
 				panic(err)
 			}
-			templateClose = tmpl.Templates()[0]
+			templateClose = tmpl.Lookup(templateCloseFile)
 		}
 
 		module := getModuleForClass(nc.App, name, viper.GetString(configRoot+".class-name"), groupWhitelist, groupBlacklist, extras, templateOpen, templateClose)

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -130,7 +130,9 @@ func TestCoordinator_Configure_SendClose(t *testing.T) {
 		if len(filenames) != 1 {
 			return nil, errors.New("expected exactly 1 filename")
 		}
-		return template.New("test").Parse("")
+		testTemplate, _ := template.New("template_close").Parse("")
+		testTemplate, _ = testTemplate.New("template_open").Parse("")
+		return testTemplate, nil
 	}
 	coordinator.Configure()
 	module := coordinator.modules["test"].(*NullNotifier)


### PR DESCRIPTION
Reason: 
`tmpl.Templates()[0]` always return the first template.
=> always return `templateOpen`
```
func parseFiles(t *Template, filenames ...string) (*Template, error) {
	if len(filenames) == 0 {
		// Not really a problem, but be consistent.
		return nil, fmt.Errorf("template: no files named in call to ParseFiles")
	}
	for _, filename := range filenames {
		b, err := ioutil.ReadFile(filename)
		if err != nil {
			return nil, err
		}
		s := string(b)
		name := filepath.Base(filename)
		// First template becomes return value if not already defined,
		// and we use that one for subsequent New calls to associate
		// all the templates together. Also, if this file has the same name
		// as t, this file becomes the contents of t, so
		//  t, err := New(name).Funcs(xxx).ParseFiles(name)
		// works. Otherwise we create a new template associated with t.
		var tmpl *Template
		if t == nil {
			t = New(name)
		}
		if name == t.Name() {
			tmpl = t
		} else {
			tmpl = t.New(name)
		}
		_, err = tmpl.Parse(s)
		if err != nil {
			return nil, err
		}
	}
	return t, nil
}
```
Solution: able to use Lookup function
```
func (t *Template) Lookup(name string) *Template {
	if t.common == nil {
		return nil
	}
	return t.tmpl[name]
}
```
