### PR TITLE
Fix an incorrect cast from #338

### DIFF
--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -257,7 +257,7 @@ func (module *InMemoryStorage) addBrokerOffset(request *protocol.StorageRequest,
 			Timestamp: request.Timestamp,
 		}
 	} else {
-		ringval, _ := partitionEntry.Value.(*protocol.ConsumerOffset)
+		ringval, _ := partitionEntry.Value.(*brokerOffset)
 		ringval.Offset = request.Offset
 		ringval.Timestamp = request.Timestamp
 	}


### PR DESCRIPTION
The code in #338 introduced a bug with a bad cast when updating broker offsets in the ring. This was in an untested code branch, so it wasn't caught. The fix is simply correcting the type that the ring value is cast to for the broker offset ring. I've also added a test of inserting many broker offsets to cover this branch.