### PR TITLE
Adjusting docker build to be self-contained

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,7 +30,7 @@ dockers:
     goarm: ''
     binary: burrow
     image: toddpalino/burrow
-    dockerfile: Dockerfile
+    dockerfile: Dockerfile.gorelease
     latest: true
     extra_files:
     - docker-config/burrow.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
+FROM golang:1.9-alpine as builder
+
+ENV DEP_VERSION="0.3.2"
+RUN apk add --no-cache git curl && \
+	curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep && \
+	chmod +x $GOPATH/bin/dep && \
+	mkdir -p $GOPATH/src/github.com/linkedin/Burrow
+
+ADD . $GOPATH/src/github.com/linkedin/Burrow/
+RUN cd $GOPATH/src/github.com/linkedin/Burrow && \
+	dep ensure && \
+	go build -o /tmp/burrow .
+
 FROM iron/go
 MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
 
 WORKDIR /app
-ADD burrow /app/
-ADD burrow.toml /etc/burrow/
+COPY --from=builder /tmp/burrow /app/
+ADD /docker-config/burrow.toml /etc/burrow/
 
 CMD ["/app/burrow", "--config-dir", "/etc/burrow"]

--- a/Dockerfile.gorelease
+++ b/Dockerfile.gorelease
@@ -1,0 +1,8 @@
+FROM iron/go
+MAINTAINER LinkedIn Burrow "https://github.com/linkedin/Burrow"
+
+WORKDIR /app
+ADD burrow /app/
+ADD burrow.toml /etc/burrow/
+
+CMD ["/app/burrow", "--config-dir", "/etc/burrow"]


### PR DESCRIPTION
Adjusting Dockerfile to support multi-stage build to ease on boarding & CI/CD builds. 

NOTE: I wasn't sure what `burrow.toml` refers to in the existing Dockerfile so I used the `docker-config/burrow.toml` to match the `go-release` configuration