### PR TITLE
Update sarama to support 10.2.1 too.

### DIFF
--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -38,7 +38,7 @@ func parseKafkaVersion(kafkaVersion string) sarama.KafkaVersion {
 		return sarama.V0_10_0_1
 	case "0.10.1", "0.10.1.0":
 		return sarama.V0_10_1_0
-	case "", "0.10.2", "0.10.2.0":
+	case "", "0.10.2", "0.10.2.0", "0.10.2.1":
 		return sarama.V0_10_2_0
 	case "0.11.0", "0.11.0.1", "0.11.0.2":
 		return sarama.V0_11_0_0


### PR DESCRIPTION
Panic when setting version to 0.10.2.1 in client-profile. Returning same thing as other 0.10.2.x It's the same client but it may be confusing for those using this specific version https://archive.apache.org/dist/kafka/0.10.2.1/RELEASE_NOTES.html