### PR TITLE
ISSUE 314: use notifier threshold to configure evaluator ShowAll

### DIFF
--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -92,6 +92,11 @@ type Coordinator struct {
 
 	clusters    map[string]*clusterGroups
 	clusterLock *sync.RWMutex
+
+	// The value of the 'ShowAll' parameter when submitting a request to
+	// the evaluator. This flag is determined based on the notifier
+	// 'threshold' configuration.
+	ShowAll           bool
 }
 
 // getModuleForClass returns the correct module based on the passed className. As part of the Configure steps, if there
@@ -162,6 +167,7 @@ func (nc *Coordinator) Configure() {
 	nc.quitChannel = make(chan struct{})
 	nc.running = sync.WaitGroup{}
 	nc.evaluatorResponse = make(chan *protocol.ConsumerGroupStatus)
+	nc.ShowAll = false
 
 	// Set the function for parsing templates and calling module Notify (configurable to enable testing)
 	if nc.templateParseFunc == nil {
@@ -183,6 +189,13 @@ func (nc *Coordinator) Configure() {
 		// Set some defaults for common module fields
 		viper.SetDefault(configRoot+".interval", 60)
 		viper.SetDefault(configRoot+".threshold", 2)
+
+		// if any of the notifier thresholds are 1, we need to fetch
+		// status of all consumer groups from the evaluator
+		threshold := viper.GetInt(configRoot+".threshold")
+		if threshold == 1 {
+		   nc.ShowAll = true
+		}
 
 		// Compile the whitelist for the consumer groups to notify for
 		var groupWhitelist *regexp.Regexp
@@ -373,6 +386,7 @@ func (nc *Coordinator) sendEvaluatorRequests() {
 							Reply:   nc.evaluatorResponse,
 							Cluster: sendCluster,
 							Group:   sendConsumer,
+							ShowAll: nc.ShowAll,
 						}
 					}(cluster, consumer)
 					groupInfo.LastEval = timeNow


### PR DESCRIPTION
Hello, 
This pull request is a proposed fix for https://github.com/linkedin/Burrow/issues/341. Prior to this change, when the 'notifier' coordinator submits an 'EvaluatorRequest', the 'ShowAll' parameter defaults to 'false'. The result is that not all StatusOK partitions are sent to the notification endpoints (i.e., 'http' and 'email').
The changes in this PR use the 'threshold' configuration property within the notifier section to set the 'ShowAll' parameter of the evaluator request. Thus, if the user has set the threshold=1, that notification endpoint will receive StatusOK partitions.
