### PR TITLE
Allow environment variables to be used for configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -83,6 +84,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Failed reading configuration:", err.Error())
 		panic(exitCode{1})
 	}
+
+	// setup viper to be able to read env variables with a configured prefix
+	viper.SetDefault("general.env-var-prefix", "burrow")
+	envPrefix := viper.GetString("general.env-var-prefix")
+	viper.SetEnvPrefix(envPrefix)
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
 
 	// Create the PID file to lock out other processes
 	viper.SetDefault("general.pidfile", "burrow.pid")


### PR DESCRIPTION
This PR sets up viper to use environment variables as part of its config. By default all env vars need to be prefixed with `burrow`. If you want to change that you can use the `general.env-var-prefix` in your configuration to change the prefix.

### Example

If you have the following configuration 

```toml
[consumer.local]
class-name="kafka"
cluster="local"
client-profile="test"
group-blacklist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
group-whitelist=""
```

you can set the `servers` property by setting the

```
BURROR_CONSUMER_LOCAL_SERVERS=kafka01.example.com:10251
```

If you don't like the `BURROW` prefix you can change that under

```toml
[general]
env-var-prefix="my-prefix"
```