### PR TITLE
Fetch goreleaser via curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ before_script:
   - go get honnef.co/go/tools/cmd/megacheck                     # Badass static analyzer/linter
   - go get github.com/fzipp/gocyclo
   - go get github.com/mattn/goveralls
-  - go get github.com/goreleaser/goreleaser
 
 # script always run to completion (set +e). All of these code checks are must haves
 # in a modern Go project.
@@ -66,4 +65,4 @@ script:
 # goreleaser will run if the latest version tag matches the current commit
 after_success:
   - $GOPATH/bin/goveralls -coverprofile=profile.cov -service=travis-ci
-  - if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$TRAVIS_GO_VERSION" == "1.9.2" ]]; then docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; goreleaser; fi
+  - if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$TRAVIS_GO_VERSION" == "1.9.2" ]]; then docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"; curl -sL https://git.io/goreleaser | bash; fi


### PR DESCRIPTION
It appears that goreleaser made changes to only support compilation in 1.10, which means that it's breaking in Travis. The preferred method, via the docs, is to curl a binary version and execute it. Which is gross, but it's what we have until we switch to golang 1.10 as the default build version.