### PR TITLE
add blacklist for memory store

### DIFF
--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -283,7 +283,6 @@ func readString(buf *bytes.Buffer) (string, error) {
 }
 
 func (module *KafkaClient) acceptConsumerGroup(group string) bool {
-	// No whitelist means everything passes
 	if (module.groupWhitelist != nil) && (!module.groupWhitelist.MatchString(group)) {
 		return false
 	}

--- a/core/internal/consumer/kafka_zk_client.go
+++ b/core/internal/consumer/kafka_zk_client.go
@@ -171,7 +171,6 @@ func (module *KafkaZkClient) connectionStateWatcher(eventChan <-chan zk.Event) {
 }
 
 func (module *KafkaZkClient) acceptConsumerGroup(group string) bool {
-	// No whitelist means everything passes
 	if (module.groupWhitelist != nil) && (!module.groupWhitelist.MatchString(group)) {
 		return false
 	}

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -351,8 +351,8 @@ func TestInMemoryStorage_addConsumerOffset_TooOld(t *testing.T) {
 
 type testset struct {
 	regexFilter  string
-	whitelistedGroups []string
-	blacklistedGroups []string
+	matchGroups []string
+	noMatchGroups []string
 }
 
 var whitelistTests = []testset{
@@ -367,11 +367,11 @@ func TestInMemoryStorage_acceptConsumerGroup_NoWhitelist(t *testing.T) {
 		module := fixtureModule(testSet.regexFilter, "")
 		module.Configure("test", "storage.test")
 
-		for _, group := range testSet.whitelistedGroups {
+		for _, group := range testSet.matchGroups {
 			result := module.acceptConsumerGroup(group)
 			assert.Truef(t, result, "TEST %v: Expected group %v to pass", i, group)
 		}
-		for _, group := range testSet.blacklistedGroups {
+		for _, group := range testSet.noMatchGroups {
 			result := module.acceptConsumerGroup(group)
 			assert.Falsef(t, result, "TEST %v: Expected group %v to fail", i, group)
 		}
@@ -381,16 +381,16 @@ func TestInMemoryStorage_acceptConsumerGroup_NoWhitelist(t *testing.T) {
 
 func TestInMemoryStorage_acceptConsumerGroup_Blacklist(t *testing.T) {
 	// just taking the inverse of TestInMemoryStorage_acceptConsumerGroup_NoWhitelist
-	// 
+	// so noMatchGroups will return true and matchGroup entries will be false.
 	for i, testSet := range whitelistTests {
 		module := fixtureModule("", testSet.regexFilter)
 		module.Configure("test", "storage.test")
 
-		for _, group := range testSet.blacklistedGroups {
+		for _, group := range testSet.noMatchGroups {
 			result := module.acceptConsumerGroup(group)
 			assert.Truef(t, result, "TEST %v: Expected group %v to pass", i, group)
 		}
-		for _, group := range testSet.whitelistedGroups {
+		for _, group := range testSet.matchGroups {
 			result := module.acceptConsumerGroup(group)
 			assert.Falsef(t, result, "TEST %v: Expected group %v to fail", i, group)
 		}

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -34,8 +34,12 @@ func fixtureModule(whitelist string, blacklist string) *InMemoryStorage {
 
 	viper.Reset()
 	viper.Set("storage.test.class-name", "inmemory")
-	viper.Set("storage.test.group-whitelist", whitelist)
-	viper.Set("storage.test.group-blacklist", blacklist)
+	if whitelist != "" {
+		viper.Set("storage.test.group-whitelist", whitelist)
+	}
+	if blacklist != "" {
+		viper.Set("storage.test.group-blacklist", blacklist)
+	}
 	viper.Set("storage.test.min-distance", 1)
 
 	return &module

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -354,13 +354,13 @@ func TestInMemoryStorage_addConsumerOffset_TooOld(t *testing.T) {
 }
 
 type testset struct {
-	regexFilter  string
-	matchGroups []string
+	regexFilter   string
+	matchGroups   []string
 	noMatchGroups []string
 }
 
 var regexFilterTests = []testset{
-	{".*", []string{"testgroup", "ok_group", "dash-group", "num02group"}, []string{}},
+	{"", []string{"testgroup", "ok_group", "dash-group", "num02group"}, []string{}},
 	{"test.*", []string{"testgroup"}, []string{"ok_group", "dash-group", "num02group"}},
 	{".*[0-9]+.*", []string{"num02group"}, []string{"ok_group", "dash-group", "testgroup"}},
 	{"onlygroup", []string{"onlygroup"}, []string{"testgroup", "ok_group", "dash-group", "num02group"}},
@@ -382,7 +382,6 @@ func TestInMemoryStorage_acceptConsumerGroup_NoWhitelist(t *testing.T) {
 	}
 }
 
-
 func TestInMemoryStorage_acceptConsumerGroup_Blacklist(t *testing.T) {
 	// just taking the inverse of TestInMemoryStorage_acceptConsumerGroup_NoWhitelist
 	// so noMatchGroups will return true and matchGroup entries will be false.
@@ -400,7 +399,6 @@ func TestInMemoryStorage_acceptConsumerGroup_Blacklist(t *testing.T) {
 		}
 	}
 }
-
 
 func TestInMemoryStorage_addConsumerOffset_MinDistance(t *testing.T) {
 	startTime := (time.Now().Unix() * 1000) - 100000

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -355,7 +355,7 @@ type testset struct {
 	noMatchGroups []string
 }
 
-var whitelistTests = []testset{
+var regexFilterTests = []testset{
 	{"", []string{"testgroup", "ok_group", "dash-group", "num02group"}, []string{}},
 	{"test.*", []string{"testgroup"}, []string{"ok_group", "dash-group", "num02group"}},
 	{".*[0-9]+.*", []string{"num02group"}, []string{"ok_group", "dash-group", "testgroup"}},
@@ -363,7 +363,7 @@ var whitelistTests = []testset{
 }
 
 func TestInMemoryStorage_acceptConsumerGroup_NoWhitelist(t *testing.T) {
-	for i, testSet := range whitelistTests {
+	for i, testSet := range regexFilterTests {
 		module := fixtureModule(testSet.regexFilter, "")
 		module.Configure("test", "storage.test")
 
@@ -382,7 +382,7 @@ func TestInMemoryStorage_acceptConsumerGroup_NoWhitelist(t *testing.T) {
 func TestInMemoryStorage_acceptConsumerGroup_Blacklist(t *testing.T) {
 	// just taking the inverse of TestInMemoryStorage_acceptConsumerGroup_NoWhitelist
 	// so noMatchGroups will return true and matchGroup entries will be false.
-	for i, testSet := range whitelistTests {
+	for i, testSet := range regexFilterTests {
 		module := fixtureModule("", testSet.regexFilter)
 		module.Configure("test", "storage.test")
 

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -360,7 +360,7 @@ type testset struct {
 }
 
 var regexFilterTests = []testset{
-	{"", []string{"testgroup", "ok_group", "dash-group", "num02group"}, []string{}},
+	{".*", []string{"testgroup", "ok_group", "dash-group", "num02group"}, []string{}},
 	{"test.*", []string{"testgroup"}, []string{"ok_group", "dash-group", "num02group"}},
 	{".*[0-9]+.*", []string{"num02group"}, []string{"ok_group", "dash-group", "testgroup"}},
 	{"onlygroup", []string{"onlygroup"}, []string{"testgroup", "ok_group", "dash-group", "num02group"}},

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -109,9 +109,16 @@ func TestInMemoryStorage_Configure_DefaultIntervals(t *testing.T) {
 	assert.Equal(t, 10, module.intervals, "Default Intervals value of 10 did not get set")
 }
 
-func TestInMemoryStorage_Configure_BadRegexp(t *testing.T) {
+func TestInMemoryStorage_Configure_BadWhitelistRegexp(t *testing.T) {
 	module := fixtureModule("", "")
 	viper.Set("storage.test.group-whitelist", "[")
+
+	assert.Panics(t, func() { module.Configure("test", "storage.test") }, "The code did not panic")
+}
+
+func TestInMemoryStorage_Configure_BadBlacklistRegexp(t *testing.T) {
+	module := fixtureModule("", "")
+	viper.Set("storage.test.group-blacklist", "[")
 
 	assert.Panics(t, func() { module.Configure("test", "storage.test") }, "The code did not panic")
 }


### PR DESCRIPTION
the consumer configuration allows defining both a blacklist and a whitelist while the memory storage only has a whitelist. This makes it more consistent, allowing both consumers and storage to be configured with the same filter.