### PR TITLE
Allow underscores in hostnames

### DIFF
--- a/core/internal/helpers/validation.go
+++ b/core/internal/helpers/validation.go
@@ -28,11 +28,11 @@ func ValidateIP(ipaddr string) bool {
 //
 // * One or more segments delimited by a '.'
 // * Each segment can be no more than 63 characters long
-// * Valid characters in a segment are letters, numbers, and dashes
+// * Valid characters in a segment are letters, numbers, dashes, and underscores
 // * Segments may not start or end with a dash
 // * The exception is IPv6 addresses, which are also permitted.
 func ValidateHostname(hostname string) bool {
-	matches, _ := regexp.MatchString(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`, hostname)
+	matches, _ := regexp.MatchString(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-_]{0,61}[a-zA-Z0-9]))*$`, hostname)
 	if !matches {
 		// Try as an IP address
 		return ValidateIP(hostname)

--- a/core/internal/helpers/validation_test.go
+++ b/core/internal/helpers/validation_test.go
@@ -49,7 +49,7 @@ var testHostnames = []TestSet{
 	{"host.example.com", true},
 	{"example.com", true},
 	{"thissegmentiswaytoolongbecauseitshouldnotbemorethansixtythreecharacters.foo.com", false},
-	{"underscores_are.not.valid.com", false},
+	{"underscores_are.valid.com", true},
 	{"800.hostnames.starting.with.numbers.are.valid.because.people.suck.org", true},
 	{"hostnames-.may.not.end.with.a.dash.com", false},
 	{"no spaces.com", false},
@@ -172,7 +172,7 @@ var testHostPorts = []TestSet{
 	{"host0:4234", true},
 	{"host.example.com:23", true},
 	{"thissegmentiswaytoolongbecauseitshouldnotbemorethansixtythreecharacters.foo.com:36334", false},
-	{"underscores_are.not.valid.com:3453", false},
+	{"underscores_are.valid.com:3453", true},
 }
 
 func TestValidateHostList(t *testing.T) {


### PR DESCRIPTION
I know that underscores aren't supposed to be valid in DNS but in our infrastructure we have underscores anyways.  Please accept this change so that we can use burrow.  

Let me know if there is any contribution process I need to follow @toddpalino.

Thank you!