### PR TITLE
Retrieve partition owners on the kafka zookeeper client

### DIFF
--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -176,6 +176,7 @@ func TestKafkaZkClient_watchGroupList(t *testing.T) {
 func TestKafkaZkClient_resetOffsetWatchAndSend_BadPath(t *testing.T) {
 	mockZookeeper := helpers.MockZookeeperClient{}
 	mockZookeeper.On("GetW", "/consumers/testgroup/offsets/testtopic/0").Return([]byte("81234"), (*zk.Stat)(nil), (<-chan zk.Event)(nil), errors.New("badpath"))
+	mockZookeeper.On("GetW", "/consumers/testgroup/owners/testtopic/0").Return([]byte("testowner"), (*zk.Stat)(nil), (<-chan zk.Event)(nil), nil)
 
 	module := fixtureKafkaZkModule()
 	module.Configure("test", "consumer.test")
@@ -196,6 +197,7 @@ func TestKafkaZkClient_resetOffsetWatchAndSend_BadOffset(t *testing.T) {
 	offsetStat := &zk.Stat{Mtime: 894859}
 	newWatchEventChan := make(chan zk.Event)
 	mockZookeeper.On("GetW", "/consumers/testgroup/offsets/testtopic/0").Return([]byte("notanumber"), offsetStat, func() <-chan zk.Event { return newWatchEventChan }(), nil)
+	mockZookeeper.On("GetW", "/consumers/testgroup/owners/testtopic/0").Return([]byte("testowner"), (*zk.Stat)(nil), (<-chan zk.Event)(nil), nil)
 
 	// This will block if a storage request is sent, as nothing is watching that channel
 	module.running.Add(1)

--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -112,6 +112,7 @@ func TestKafkaZkClient_watchGroupList(t *testing.T) {
 	mockZookeeper.On("ExistsW", "/consumers/testgroup/offsets").Return(true, offsetStat, func() <-chan zk.Event { return topicExistsChan }(), nil)
 	mockZookeeper.On("ChildrenW", "/consumers/testgroup/offsets/testtopic").Return([]string{"0"}, offsetStat, func() <-chan zk.Event { return newPartitionChan }(), nil)
 	mockZookeeper.On("GetW", "/consumers/testgroup/offsets/testtopic/0").Return([]byte("81234"), offsetStat, func() <-chan zk.Event { return newOffsetChan }(), nil)
+	mockZookeeper.On("GetW", "/consumers/testgroup/owners/testtopic/0").Return([]byte("testowner"), offsetStat, func() <-chan zk.Event { return newOffsetChan }(), nil)
 
 	watchEventChan := make(chan zk.Event)
 
@@ -158,6 +159,10 @@ func TestKafkaZkClient_watchGroupList(t *testing.T) {
 			State: zk.StateConnected,
 			Path:  "/consumers/testgroup/offsets/testtopic/1/shouldntgetcalled",
 		}
+
+		secondRequest := <-module.App.StorageChannel
+		assert.Equalf(t, protocol.StorageSetConsumerOwner, secondRequest.RequestType, "Expected request sent with type StorageSetConsumerOwner, not %v", secondRequest.RequestType)
+		assert.Equalf(t, "testowner", secondRequest.Owner, "Expected request sent with Owner testowner, not %v", secondRequest.Owner)
 	}()
 
 	module.running.Add(1)


### PR DESCRIPTION
At the moment, if using a consumer that is subscribed to Zookeeper, the owner/consumer id (as reported by Burrow) is empty:

```
{
  "topic": "apache_accesslog_proto",
  "partition": 9,
  "owner": "",
  "status": "OK",
  "start": {
    "offset": 20067155234,
    "timestamp": 1530025635775,
    "lag": 958525
  },
  "end": {
    "offset": 20067187005,
    "timestamp": 1530025680131,
    "lag": 999891
  },
  "current_lag": 999891,
  "complete": 1
}
```

This information is useful while debugging consumers that are lagging behind. With this PR the value is read from the `owners` path stored in ZK.