### PR TITLE
Fixed pid check in docker containers

### DIFF
--- a/core/logger.go
+++ b/core/logger.go
@@ -47,6 +47,14 @@ func CheckAndCreatePidFile(filename string) bool {
 			return false
 		}
 
+		if pid == os.Getpid() {
+			// This could happen inside a docker
+			// container, e.g. the pid of Burrow could be
+			// equal to 1 each time the container is
+			// restarted.
+			return true
+		}
+
 		// Try sending a signal to the process to see if it is still running
 		process, err := os.FindProcess(int(pid))
 		if err == nil {

--- a/core/logger.go
+++ b/core/logger.go
@@ -52,6 +52,7 @@ func CheckAndCreatePidFile(filename string) bool {
 			// container, e.g. the pid of Burrow could be
 			// equal to 1 each time the container is
 			// restarted.
+			fmt.Println("Found existing pidfile matching current pid")
 			return true
 		}
 
@@ -61,7 +62,7 @@ func CheckAndCreatePidFile(filename string) bool {
 			err = process.Signal(syscall.Signal(0))
 			if (err == nil) || (err == syscall.EPERM) {
 				// The process exists, so we're going to assume it's an old Burrow and we shouldn't start
-				fmt.Printf("Existing process running on PID %d. Exiting", pid)
+				fmt.Printf("Existing process running on PID %d. Exiting (my pid = %d)", pid, os.Getpid())
 				return false
 			}
 		}


### PR DESCRIPTION
We run Burrow inside a docker container, and we found that Burrow repeated exists with errors like this:

```
Existing process running on PID 1. ExitingReading configuration from /etc/burrow
Burrow failed at June 28, 2018 at 1:51am (UTC)
Existing process running on PID 1. ExitingReading configuration from /etc/burrow
Burrow failed at June 28, 2018 at 1:52am (UTC)
Existing process running on PID 1. ExitingReading configuration from /etc/burrow
Burrow failed at June 28, 2018 at 1:53am (UTC)
```

After a bit of debugging it seems:
* burrow tries to read the pid file `/burrow.pid` 
* and it founds the pid is 1
* and it founds the process with pid 1 is still running (but actually it's itself)
* thinking another instance is running, Burrow exits happily.

The main problem is the pid due to the fact that the pid of Burrow is always the same (1 in our case) after a docker container is restarted.