### PR TITLE
Support linux/arm64 using Dup3() instead of Dup2()

### DIFF
--- a/core/open_out_log_linux_arm64.go
+++ b/core/open_out_log_linux_arm64.go
@@ -1,5 +1,4 @@
-// +build !windows
-// +build !arm64
+// +build linux,arm64
 
 /* Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
  * 2.0 (the "License"); you may not use this file except in compliance with
@@ -17,6 +16,8 @@ import (
 	"syscall"
 )
 
+// linux_arm64 doesn't have syscall.Dup2, so use
+// the nearly identical syscall.Dup3 instead
 func internalDup2(oldfd uintptr, newfd uintptr) error {
-	return syscall.Dup2(int(oldfd), int(newfd))
+	return syscall.Dup3(int(oldfd), int(newfd), 0)
 }


### PR DESCRIPTION
Dup3() will be used for linux on arm64 since Dup2() is unavailable.
The rest linux arches will still use Dup2().

Otherwise linux/arm64 building fails with:
src/github.com/linkedin/Burrow/core/open_out_log_unix.go:20:9: undefined: syscall.Dup2

Example of error from debian package auto-building:
https://buildd.debian.org/status/fetch.php?pkg=burrow&arch=arm64&ver=1.1.0-1&stamp=1528200955&raw=0