### PR TITLE
Configure sarama client to populate the Errors channel

### DIFF
--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -70,6 +70,7 @@ func GetSaramaConfigFromClientProfile(profileName string) *sarama.Config {
 	saramaConfig := sarama.NewConfig()
 	saramaConfig.ClientID = viper.GetString(configRoot + ".client-id")
 	saramaConfig.Version = parseKafkaVersion(viper.GetString(configRoot + ".kafka-version"))
+	saramaConfig.Consumer.Return.Errors = true
 
 	// Configure TLS if enabled
 	if viper.IsSet(configRoot + ".tls") {


### PR DESCRIPTION
From the [docs](https://godoc.org/github.com/Shopify/sarama#Config), `Consumer.Return.Errors`:

> If enabled, any errors that occurred while consuming are returned on the Errors channel (default disabled).

Currently burrow [consumes](https://github.com/linkedin/Burrow/blob/19bafdced76d338efe8348e1c794c66e1bff8916/core/internal/consumer/kafka_client.go#L171-L176) from this channel (logging any errors that show up), but as it's currently configured sarama will never send any.