### PR TITLE
core/internal/httpserver: set the content type when writing JSON

### DIFF
--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -246,6 +246,8 @@ func (hc *Coordinator) writeResponse(w http.ResponseWriter, r *http.Request, sta
 		w.Header().Set("Access-Control-Allow-Origin", corsHeader)
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+
 	if jsonBytes, err := json.Marshal(jsonObj); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("{\"error\":true,\"message\":\"could not encode JSON\",\"result\":{}}"))


### PR DESCRIPTION
Since `writeResponse` always writes a JSON document hardcode the `Content-Type`. 

It's not strictly necessary but it's nice to have it because that way with Firefox I get a pretty UI which makes it easier to interpret the data. With `text-plain` this doesn't work.