### PR TITLE
Bump sarama to 1.20.1

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.20.0"
+  version = "1.20.1"
 
 [[constraint]]
   name = "go.uber.org/zap"


### PR DESCRIPTION
Release notes: https://github.com/Shopify/sarama/releases/tag/v1.20.1.