### PR TITLE
travis: test output of gofmt as a single argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 # script always run to completion (set +e). All of these code checks are must haves
 # in a modern Go project.
 script:
-  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
+  - test -z "$(gofmt -s -l $GO_FILES)"       # Fail if a .go file hasn't been formatted with gofmt
   - go test --timeout 5s -v -race ./...      # Run all the tests with the race detector enabled
   - ./testAndCover.sh                        # Run the tests again to get coverage info
   - go vet -composites=false ./...           # go vet is the official Go static analyzer


### PR DESCRIPTION
This just fixes a confusing error I got from https://travis-ci.org/linkedin/Burrow/jobs/489377558:

```
$ test -z $(gofmt -s -l $GO_FILES)
/home/travis/.travis/functions: line 104: test: too many arguments
The command "test -z $(gofmt -s -l $GO_FILES)" exited with 2.
```

I thought it was saying some _go code_ had too many arguments, but it was actually bash passing hundreds of arguments to `test -z` (one for each token in my non-formatted code files). Bash whitespace strikes again...