### PR TITLE
Fixed: *storage.brokerOffset has value nil when no leader election for partition

### DIFF
--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -625,7 +625,9 @@ func (module *InMemoryStorage) fetchTopic(request *protocol.StorageRequest, requ
 
 	offsetList := make([]int64, 0, len(topicList))
 	for _, partition := range topicList {
-		offsetList = append(offsetList, partition.Value.(*brokerOffset).Offset)
+		if partition.Value != nil {
+			offsetList = append(offsetList, partition.Value.(*brokerOffset).Offset)
+		}
 	}
 	clusterMap.brokerLock.RUnlock()
 


### PR DESCRIPTION
Fix of nil object occurs when the topic partition has no leader.

When kafka topic partition has no leader elected, *storage.brokerOffset has value nil due to which panic occurs which make burrow killed.

Issue:
#365 

Error:
```
{"level":"info","ts":1536242535.6792066,"msg":"Authenticated: id=533023954358042845, timeout=30000","type":"module","coordinator":"consumer","class":"kafka_zk","name":"local_zk"}
{"level":"info","ts":1536242535.6792336,"msg":"Re-submitting 'O' credentials after reconnect","type":"module","coordinator":"consumer","class":"kafka_zk","name":"local_zk"}
{"level":"info","ts":1536242548.634885,"msg":"cluster or consumer not found","type":"module","coordinator":"evaluator","class":"caching","name":"default","cluster":"local","consumer":"kmf-consumer-group-1703177943","showall":true}
{"level":"info","ts":1536242548.6358068,"msg":"cluster or consumer not found","type":"module","coordinator":"evaluator","class":"caching","name":"default","cluster":"local","consumer":"kmf-consumer-group--799769738","showall":true}
{"level":"info","ts":1536242548.6360395,"msg":"cluster or consumer not found","type":"module","coordinator":"evaluator","class":"caching","name":"default","cluster":"local","consumer":"KafkaManagerOffsetCache","showall":true}
{"level":"info","ts":1536242548.6362813,"msg":"cluster or consumer not found","type":"module","coordinator":"evaluator","class":"caching","name":"default","cluster":"local","consumer":"KMOffsetCache-kafka-manager-7df68cd498-rcdmr","showall":true}
panic: interface conversion: interface {} is nil, not *storage.brokerOffset

goroutine 48 [running]:
github.com/linkedin/Burrow/core/internal/storage.(*InMemoryStorage).fetchTopic(0xc42009bf40, 0xc422b8f2d0, 0xc4223ca180)
        /go/src/github.com/linkedin/Burrow/core/internal/storage/inmemory.go:611 +0x3ee
github.com/linkedin/Burrow/core/internal/storage.(*InMemoryStorage).(github.com/linkedin/Burrow/core/internal/storage.fetchTopic)-fm(0xc422b8f2d0, 0xc4223ca180)
        /go/src/github.com/linkedin/Burrow/core/internal/storage/inmemory.go:182 +0x3e
github.com/linkedin/Burrow/core/internal/storage.(*InMemoryStorage).requestWorker(0xc42009bf40, 0x8, 0xc4201a6360)
        /go/src/github.com/linkedin/Burrow/core/internal/storage/inmemory.go:190 +0x1003
created by github.com/linkedin/Burrow/core/internal/storage.(*InMemoryStorage).Start
        /go/src/github.com/linkedin/Burrow/core/internal/storage/inmemory.go:144 +0x336
```


Solution: 
Before appending brokerOffset to OffsetList adding an if condition which checks partition.Value should not be null.