### PR TITLE
Groupmeta v2

### DIFF
--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -62,10 +62,11 @@ type offsetValue struct {
 	ErrorAt   string
 }
 type metadataHeader struct {
-	ProtocolType string
-	Generation   int32
-	Protocol     string
-	Leader       string
+	ProtocolType          string
+	Generation            int32
+	Protocol              string
+	Leader                string
+	CurrentStateTimestamp int64
 }
 type metadataMember struct {
 	MemberID         string
@@ -392,7 +393,7 @@ func (module *KafkaClient) decodeGroupMetadata(keyBuffer *bytes.Buffer, value []
 	}
 
 	switch valueVersion {
-	case 0, 1:
+	case 0, 1, 2:
 		module.decodeAndSendGroupMetadata(valueVersion, group, valueBuffer, logger.With(
 			zap.String("message_type", "metadata"),
 			zap.String("group", group),
@@ -408,12 +409,20 @@ func (module *KafkaClient) decodeGroupMetadata(keyBuffer *bytes.Buffer, value []
 }
 
 func (module *KafkaClient) decodeAndSendGroupMetadata(valueVersion int16, group string, valueBuffer *bytes.Buffer, logger *zap.Logger) {
-	metadataHeader, errorAt := decodeMetadataValueHeader(valueBuffer)
+	var metadataHeader metadataHeader
+	var errorAt string
+	switch valueVersion {
+	case 2:
+		metadataHeader, errorAt = decodeMetadataValueHeaderV2(valueBuffer)
+	default:
+		metadataHeader, errorAt = decodeMetadataValueHeader(valueBuffer)
+	}
 	metadataLogger := logger.With(
 		zap.String("protocol_type", metadataHeader.ProtocolType),
 		zap.Int32("generation", metadataHeader.Generation),
 		zap.String("protocol", metadataHeader.Protocol),
 		zap.String("leader", metadataHeader.Leader),
+		zap.Int64("current_state_timestamp", metadataHeader.CurrentStateTimestamp),
 	)
 	if errorAt != "" {
 		metadataLogger.Warn("failed to decode",
@@ -488,6 +497,33 @@ func decodeMetadataValueHeader(buf *bytes.Buffer) (metadataHeader, string) {
 	metadataHeader.Leader, err = readString(buf)
 	if err != nil {
 		return metadataHeader, "leader"
+	}
+	return metadataHeader, ""
+}
+
+func decodeMetadataValueHeaderV2(buf *bytes.Buffer) (metadataHeader, string) {
+	var err error
+	metadataHeader := metadataHeader{}
+
+	metadataHeader.ProtocolType, err = readString(buf)
+	if err != nil {
+		return metadataHeader, "protocol_type"
+	}
+	err = binary.Read(buf, binary.BigEndian, &metadataHeader.Generation)
+	if err != nil {
+		return metadataHeader, "generation"
+	}
+	metadataHeader.Protocol, err = readString(buf)
+	if err != nil {
+		return metadataHeader, "protocol"
+	}
+	metadataHeader.Leader, err = readString(buf)
+	if err != nil {
+		return metadataHeader, "leader"
+	}
+	err = binary.Read(buf, binary.BigEndian, &metadataHeader.CurrentStateTimestamp)
+	if err != nil {
+		return metadataHeader, "current_state_timestamp"
 	}
 	return metadataHeader, ""
 }

--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -544,7 +544,7 @@ func decodeMetadataMember(buf *bytes.Buffer, memberVersion int16) (metadataMembe
 	if err != nil {
 		return memberMetadata, "client_host"
 	}
-	if memberVersion == 1 {
+	if memberVersion == 1 || memberVersion == 2 {
 		err = binary.Read(buf, binary.BigEndian, &memberMetadata.RebalanceTimeout)
 		if err != nil {
 			return memberMetadata, "rebalance_timeout"

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -227,6 +227,7 @@ func (module *CachingEvaluator) evaluateConsumerStatus(clusterAndConsumer string
 			partitionStatus.Topic = topic
 			partitionStatus.Partition = int32(partitionID)
 			partitionStatus.Owner = partition.Owner
+			partitionStatus.ClientID = partition.ClientID
 
 			if partitionStatus.Status > status.Status {
 				// If the partition status is greater than StatusError, we just mark it as StatusError


### PR DESCRIPTION
Addresses [#505](https://github.com/linkedin/Burrow/issues/505)
Adds support for group metadata schema version 2

Enhances [PR#491](https://github.com/linkedin/Burrow/pull/491)
Adds client_id reporting when requesting status/partitionstatus.
