### PR TITLE
Upgrade sarama to support Kafka 2.2.0

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,6 +1,6 @@
 [[constraint]]
   name = "github.com/Shopify/sarama"
-  version = "1.21.0"
+  version = "1.22.0"
 
 [[constraint]]
   name = "go.uber.org/zap"

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -48,6 +48,7 @@ var kafkaVersions = map[string]sarama.KafkaVersion{
 	"2.0.0":    sarama.V2_0_0_0,
 	"2.0.1":    sarama.V2_0_0_0,
 	"2.1.0":    sarama.V2_1_0_0,
+	"2.2.0":    sarama.V2_2_0_0,
 }
 
 func parseKafkaVersion(kafkaVersion string) sarama.KafkaVersion {


### PR DESCRIPTION
Upgrade Shopify/sarama to 1.22.0
to support kafaka 2.2.0

Just like PR: https://github.com/linkedin/Burrow/pull/447