### PR TITLE
Update lagging state

### DIFF
--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -379,12 +379,15 @@ func checkIfOffsetsStalled(offsets []*protocol.ConsumerOffset) bool {
 
 // Rule 5 - If the consumer offsets are advancing, but the lag is not decreasing somewhere, it's a warning (consumer is slow)
 func checkIfLagNotDecreasing(offsets []*protocol.ConsumerOffset) bool {
+	lagChange := int64(0)
 	for i := 1; i < len(offsets); i++ {
-		if offsets[i].Lag < offsets[i-1].Lag {
-			return false
+		if offsets[i].Lag == 0 {
+			lagChange = 0
+		} else {
+			lagChange += int64(offsets[i].Lag - offsets[i-1].Lag)
 		}
 	}
-	return true
+	return lagChange >= 0
 }
 
 // Using the most recent committed offset, return true if there was zero lag at some point in the stored broker

--- a/core/internal/evaluator/caching_test.go
+++ b/core/internal/evaluator/caching_test.go
@@ -360,7 +360,7 @@ var tests = []testset{
 		checkIfOffsetsRewind:    true,
 		checkIfOffsetsStopped:   false,
 		checkIfOffsetsStalled:   false,
-		checkIfLagNotDecreasing: false,
+		checkIfLagNotDecreasing: true,
 		checkIfRecentLagZero:    false,
 		status:                  protocol.StatusRewind,
 	},
@@ -446,6 +446,27 @@ var tests = []testset{
 		checkIfLagNotDecreasing: true,
 		checkIfRecentLagZero:    true,
 		status:                  protocol.StatusOK,
+	},
+
+	// 11 - status is WARN because the offsets are not decreasing but commits continue
+	{
+		offsets: []*protocol.ConsumerOffset{
+			{1000, 100000, 50},
+			{2000, 200000, 100},
+			{3000, 300000, 150},
+			{4000, 400000, 200},
+			{5000, 500000, 250},
+		},
+		brokerOffsets:           []int64{6000},
+		currentLag:              100,
+		timeNow:                 900,
+		isLagAlwaysNotZero:      true,
+		checkIfOffsetsRewind:    false,
+		checkIfOffsetsStopped:   false,
+		checkIfOffsetsStalled:   false,
+		checkIfLagNotDecreasing: true,
+		checkIfRecentLagZero:    false,
+		status:                  protocol.StatusWarning,
 	},
 }
 


### PR DESCRIPTION
Changes `checkIfLagNotDecreasing` to track if the lag over time is not decreasing. Previously it would not set this state if at any point the lag decreased which could cause lag to continuously increase with no alerts. 

