### PR TITLE
Use system SSL store for notifiers by default

### DIFF
--- a/core/internal/notifier/helpers.go
+++ b/core/internal/notifier/helpers.go
@@ -121,7 +121,12 @@ func templateCountPartitions(partitions []*protocol.PartitionStatus) map[string]
 
 // Appends supplied certificates to trusted certificate chain
 func buildRootCAs(extraCaFile string, noVerify bool) *x509.CertPool {
-	rootCAs := x509.NewCertPool()
+
+	rootCAs, caError := x509.SystemCertPool()
+	if caError != nil {
+		log.Println("Unable to load system certs, using empty cert pool instead")
+		rootCAs = x509.NewCertPool()
+	}
 
 	if extraCaFile != "" && !noVerify {
 		certs, err := ioutil.ReadFile(extraCaFile)


### PR DESCRIPTION
A fix to issue #540, using the system store by default (if possible), and adding any extra certificates to that (if applicable).