### PR TITLE
Add zap.Logger adapter for sarama

### DIFF
--- a/core/burrow.go
+++ b/core/burrow.go
@@ -23,9 +23,11 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/Shopify/sarama"
 	"github.com/linkedin/Burrow/core/internal/cluster"
 	"github.com/linkedin/Burrow/core/internal/consumer"
 	"github.com/linkedin/Burrow/core/internal/evaluator"
+	"github.com/linkedin/Burrow/core/internal/helpers"
 	"github.com/linkedin/Burrow/core/internal/httpserver"
 	"github.com/linkedin/Burrow/core/internal/notifier"
 	"github.com/linkedin/Burrow/core/internal/storage"
@@ -131,6 +133,9 @@ func Start(app *protocol.ApplicationContext, exitChannel chan os.Signal) int {
 
 	// Set up a specific child logger for main
 	log := app.Logger.With(zap.String("type", "main"), zap.String("name", "burrow"))
+
+	// Set up the logger for sarama
+	sarama.Logger = helpers.NewSaramaLogger(app.Logger.With(zap.String("name", "sarama")))
 
 	// Set up an array of coordinators in the order they are to be loaded (and closed)
 	coordinators := newCoordinators(app)

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Shopify/sarama"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 )
 
 var kafkaVersions = map[string]sarama.KafkaVersion{
@@ -522,4 +523,28 @@ func (m *MockSaramaPartitionConsumer) Errors() <-chan *sarama.ConsumerError {
 func (m *MockSaramaPartitionConsumer) HighWaterMarkOffset() int64 {
 	args := m.Called()
 	return args.Get(0).(int64)
+}
+
+// SaramaLogger wraps zap.Logger with the sarama.StdLogger interface
+type SaramaLogger struct {
+	logger *zap.SugaredLogger
+}
+
+// NewSaramaLogger initializes a new SaramaLogger with a zap.Logger
+func NewSaramaLogger(zl *zap.Logger) *SaramaLogger {
+	return &SaramaLogger{
+		logger: zl.Sugar(),
+	}
+}
+
+func (s *SaramaLogger) Print(v ...interface{}) {
+	s.logger.Info(v...)
+}
+
+func (s *SaramaLogger) Printf(format string, v ...interface{}) {
+	s.logger.Infof(format, v...)
+}
+
+func (s *SaramaLogger) Println(v ...interface{}) {
+	s.logger.Info(v...)
 }


### PR DESCRIPTION
This adds:

* A `SaramaLogger` struct that wraps a `zap.Logger` with the `sarama.StdLogger` interface
* Configures sarama to use this new logger

SaramaLogger uses `zap.SugaredLogger` internally for its `Print(...)` and `Printf(...)` functions.

This results in log messages from sarama with the same structured format as the rest of the logging: 

```
{"level":"info","ts":1567704918.2796876,"msg":"client/metadata fetching metadata for all topics from broker kafka-broker-1.internal.network:9092\n","name":"sarama"}
```

This was helpful for debugging SSL connection issues, ref #563.