### PR TITLE
Make DisableKeepAlives configurable 

### DIFF
--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -95,8 +95,9 @@ func (module *HTTPNotifier) Configure(name string, configRoot string) {
 			Dial: (&net.Dialer{
 				KeepAlive: viper.GetDuration(configRoot+".keepalive") * time.Second,
 			}).Dial,
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsConfig,
+			Proxy:             http.ProxyFromEnvironment,
+			TLSClientConfig:   tlsConfig,
+			DisableKeepAlives: viper.GetBool(configRoot + ".disable-http-keepalive"),
 		},
 	}
 }


### PR DESCRIPTION
When working through configuring Burrow's http notifier to POST to Splunk's HTTP Event Collector endpoint, we noticed sporadic EOF errors in the logs. 

`{"level":"error", ... "msg":"failed to send","type":"module","coordinator":"notifier","class":"http", ... "status":"ERR","error":"Post https://.../services/collector/event: EOF"}`

This was causing data to be missed and not sent to Splunk. After much troubleshooting, we discovered we needed to set `DisableKeepAlives` to true. 

```
// DisableKeepAlives, if true, disables HTTP keep-alives and
// will only use the connection to the server for a single
// HTTP request.
```

This change adds a new configuration value `disable-http-keepalive` which sets DisableKeepAlives on the net/http/transport.

Note: if this solution is accepted, we will want to add this new value to the `Notifier-HTTP.md`