### PR TITLE
Added 2.2.1 supporting version

### DIFF
--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -49,6 +49,7 @@ var kafkaVersions = map[string]sarama.KafkaVersion{
 	"2.0.1":    sarama.V2_0_0_0,
 	"2.1.0":    sarama.V2_1_0_0,
 	"2.2.0":    sarama.V2_2_0_0,
+	"2.2.1":    sarama.V2_2_0_0,
 	"2.3.0":    sarama.V2_3_0_0,
 }
 


### PR DESCRIPTION
Duplicate from https://github.com/linkedin/Burrow/issues/586

This is to support Kafka 2.2.1 which is the only other option currently in AWS MSK other than V1.

Very simple change but initial tests seem to work. A colleague has been working with this version against MSK 2.2.1 and not found any issue so far.