### PR TITLE
Improve zk lock method to avoid trying lock errors

### DIFF
--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -318,6 +318,10 @@ func (nc *Coordinator) manageEvalLoop() {
 		for !nc.App.ZookeeperConnected {
 			time.Sleep(100 * time.Millisecond)
 		}
+		err = lock.Unlock()
+		if err != nil {
+			panic("Unable to release zookeeper lock after session expiration")
+		}
 	}
 }
 

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -13,10 +13,10 @@
 package notifier
 
 import (
-	"sync"
-	"testing"
 	"errors"
+	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -15,6 +15,8 @@ package notifier
 import (
 	"sync"
 	"testing"
+	"errors"
+	"sync/atomic"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -119,14 +121,32 @@ func TestCoordinator_manageEvalLoop_Expiration(t *testing.T) {
 	assert.False(t, coordinator.doEvaluations, "Expected doEvaluations to be false")
 }
 
+type statefulMockLock struct {
+	*helpers.MockZookeeperLock
+	lockHeld *int32
+}
+
+func (s *statefulMockLock) Lock() error {
+	if atomic.CompareAndSwapInt32(s.lockHeld, 0, 1) {
+		return nil
+	}
+	return errors.New("unable to lock twice: must unlock first")
+}
+
+func (s *statefulMockLock) Unlock() error {
+	if atomic.CompareAndSwapInt32(s.lockHeld, 1, 0) {
+		return nil
+	}
+	return errors.New("unable to unlock: lock not held")
+}
+
 // We know this will trigger the race detector, because of the way we manipulate the ZK state
 func TestCoordinator_manageEvalLoop_Reconnect(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	coordinator.Configure()
 
 	// Add mock calls for the Zookeeper client - Lock immediately returns with no error
-	mockLock := &helpers.MockZookeeperLock{}
-	mockLock.On("Lock").Return(nil)
+	mockLock := &statefulMockLock{&helpers.MockZookeeperLock{}, new(int32)}
 	mockZk := coordinator.App.Zookeeper.(*helpers.MockZookeeperClient)
 	mockZk.On("NewLock", "/burrow/notifier").Return(mockLock)
 


### PR DESCRIPTION
failed to get zk lock on Burrow (#322)
Get fix from https://github.com/Root-App/Burrow/pull/1/files.