### PR TITLE
Fix self-reporting of burrow's own progress

### DIFF
--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -252,6 +252,7 @@ func (module *KafkaClient) partitionConsumer(consumer sarama.PartitionConsumer, 
 					Group:       module.reportedConsumerGroup,
 					Timestamp:   time.Now().Unix() * 1000,
 					Offset:      msg.Offset + 1, // emulating a consumer which should commit (lastSeenOffset+1)
+					Order:       msg.Offset,
 				}
 				helpers.TimeoutSendStorageRequest(module.App.StorageChannel, burrowOffset, 1)
 			}


### PR DESCRIPTION
Fixes a bug in #528 where burrow's own consumer progress would be ignored by the inmemory storage (my apologies, this was subtly broken in the original PR due to a bad rebase).

While I was diagnosing, I realised the backfill consumer wouldn't self-report burrow's final commit, which isn't really a problem for an active system (there will be more soon) but I've fixed that too.