### PR TITLE
add and expose observedAt time for lag entries

### DIFF
--- a/core/protocol/storage.go
+++ b/core/protocol/storage.go
@@ -192,6 +192,9 @@ type ConsumerOffset struct {
 	// The timestamp at which the offset was committed
 	Timestamp int64 `json:"timestamp"`
 
+	// The timestamp at which the commit was seen by burrow
+	ObservedTimestamp int64 `json:"observedAt"`
+
 	// The number of messages that the consumer was behind at the time that the offset was committed. This number is
 	// not updated after the offset was committed, so it does not represent the current lag of the consumer.
 	Lag *Lag `json:"lag"`


### PR DESCRIPTION
When `start-latest` is false (or when `backfill-earliest` is true for a consumer with infrequent commits), burrow churns through a lot of old commits on startup. Naively that looks bad, because old commits have huge amounts of lag when compared to the current end-offset.

This PR exposes an `observedAt` field on lag objects for when burrow _saw_ the commit, so that consumers of the HTTP API can make their own decisions about how to treat historical commits.

In our case, we use this to only alert on lag metrics where the lag is either:
 - accurate: observed within 30s of the commit occurring (according to the lag's `timestamp`)
 - final: observed more than 30s ago. The assumption being that if burrow is catching up on old commits, it'll see new commits at a rapid pace. If it hasn't seen a new commit (for a given `(consumer,partition)`) in over 30s, it's likely the consumer really did get stuck, so we don't want to ignore this.

I don't think that kind of logic makes sense to embed in burrow, but it's very useful for consumers of the API to make their own decisions.