### PR TITLE
Apply changes to Yext fork of Burrow from rjh-yext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,8 @@ RUN go mod tidy && go build -o /tmp/burrow .
 # stage 2: runner
 FROM alpine:3.11
 
-LABEL maintainer="LinkedIn Burrow https://github.com/linkedin/Burrow"
+#LABEL maintainer="LinkedIn Burrow https://github.com/linkedin/Burrow"
 
 COPY --from=builder /tmp/burrow /app/
-COPY docker-config/burrow.toml /etc/burrow/
 
-CMD ["/app/burrow", "--config-dir", "/etc/burrow"]
+CMD ["/app/burrow", "--config-dir", "/srv/burrow"]

--- a/core/burrow.go
+++ b/core/burrow.go
@@ -13,9 +13,9 @@
 // logging and application management (such as PID files), as well as the Start method that runs Burrow itself.
 //
 // The documentation for the rest of the internals, including all the available modules, is available at
-// https://godoc.org/github.com/linkedin/Burrow/core/internal/?m=all. For the most part, end users of Burrow should not
+// https://godoc.org/github.com/yext/Burrow/core/internal/?m=all. For the most part, end users of Burrow should not
 // need to refer to this documentation, as it is targeted at developers of Burrow modules. Details on what modules are
-// available and how to configure them are available at https://github.com/linkedin/Burrow/wiki
+// available and how to configure them are available at https://github.com/yext/Burrow/wiki
 package core
 
 import (
@@ -23,15 +23,14 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/cluster"
-	"github.com/linkedin/Burrow/core/internal/consumer"
-	"github.com/linkedin/Burrow/core/internal/evaluator"
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/internal/httpserver"
-	"github.com/linkedin/Burrow/core/internal/notifier"
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/internal/zookeeper"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/cluster"
+	"github.com/yext/Burrow/core/internal/consumer"
+	"github.com/yext/Burrow/core/internal/evaluator"
+	"github.com/yext/Burrow/core/internal/httpserver"
+	"github.com/yext/Burrow/core/internal/notifier"
+	"github.com/yext/Burrow/core/internal/storage"
+	"github.com/yext/Burrow/core/internal/zookeeper"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func newCoordinators(app *protocol.ApplicationContext) [7]protocol.Coordinator {

--- a/core/internal/cluster/coordinator.go
+++ b/core/internal/cluster/coordinator.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // A "cluster" is a single Kafka cluster that is going to be monitored by Burrow. The cluster module is responsible for

--- a/core/internal/cluster/coordinator_test.go
+++ b/core/internal/cluster/coordinator_test.go
@@ -13,8 +13,8 @@ package cluster
 import (
 	"testing"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"

--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -18,8 +18,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // KafkaCluster is a cluster module which connects to a single Apache Kafka cluster and manages the broker topic and

--- a/core/internal/cluster/kafka_cluster_test.go
+++ b/core/internal/cluster/kafka_cluster_test.go
@@ -24,8 +24,8 @@ import (
 
 	"sync"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureModule() *KafkaCluster {

--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -28,8 +28,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // The consumer module is responsible for fetching information about consumer group status from some external system

--- a/core/internal/consumer/coordinator_test.go
+++ b/core/internal/consumer/coordinator_test.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -22,8 +22,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // KafkaClient is a consumer module which connects to a single Apache Kafka cluster and reads consumer group information

--- a/core/internal/consumer/kafka_client_test.go
+++ b/core/internal/consumer/kafka_client_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureModule() *KafkaClient {

--- a/core/internal/consumer/kafka_zk_client.go
+++ b/core/internal/consumer/kafka_zk_client.go
@@ -20,8 +20,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 type topicList struct {

--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -13,21 +13,17 @@ package consumer
 import (
 	"errors"
 	"time"
-
+	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"github.com/samuel/go-zookeeper/zk"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
-	"sync"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureKafkaZkModule() *KafkaZkClient {

--- a/core/internal/evaluator/caching.go
+++ b/core/internal/evaluator/caching.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // CachingEvaluator is an evaluator module that responds to evaluation requests and checks consumer status using the

--- a/core/internal/evaluator/caching_test.go
+++ b/core/internal/evaluator/caching_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/storage"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureModule() (*storage.Coordinator, *CachingEvaluator) {

--- a/core/internal/evaluator/coordinator.go
+++ b/core/internal/evaluator/coordinator.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // Module is responsible for answering requests to evaluate the status of a consumer group. It fetches offset

--- a/core/internal/evaluator/coordinator_test.go
+++ b/core/internal/evaluator/coordinator_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/evaluator/fixtures.go
+++ b/core/internal/evaluator/fixtures.go
@@ -14,8 +14,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/storage"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/storage"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // StorageAndEvaluatorCoordinatorsWithOffsets sets up a Coordinator with a single caching module defined. In order to do

--- a/core/internal/helpers/coordinators.go
+++ b/core/internal/helpers/coordinators.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // StartCoordinatorModules is a helper func for coordinators to start a list of modules. Given a map of protocol.Module,

--- a/core/internal/helpers/coordinators_test.go
+++ b/core/internal/helpers/coordinators_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func TestStartCoordinatorModules(t *testing.T) {

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -124,6 +124,18 @@ func GetSaramaConfigFromClientProfile(profileName string) *sarama.Config {
 		saslName := viper.GetString(configRoot + ".sasl")
 
 		saramaConfig.Net.SASL.Enable = true
+		mechanism := viper.GetString("sasl." + saslName + ".mechanism")
+		if mechanism == "SCRAM-SHA-256" {
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA256
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+				return &XDGSCRAMClient{HashGeneratorFcn: SHA256}
+			}
+		} else if mechanism == "SCRAM-SHA-512" {
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypeSCRAMSHA512
+			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
+				return &XDGSCRAMClient{HashGeneratorFcn: SHA512}
+			}
+		}
 		saramaConfig.Net.SASL.Handshake = viper.GetBool("sasl." + saslName + ".handshake-first")
 		saramaConfig.Net.SASL.User = viper.GetString("sasl." + saslName + ".username")
 		saramaConfig.Net.SASL.Password = viper.GetString("sasl." + saslName + ".password")

--- a/core/internal/helpers/scram.go
+++ b/core/internal/helpers/scram.go
@@ -1,0 +1,36 @@
+package helpers
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+
+	"github.com/xdg/scram"
+)
+
+var SHA256 scram.HashGeneratorFcn = func() hash.Hash { return sha256.New() }
+var SHA512 scram.HashGeneratorFcn = func() hash.Hash { return sha512.New() }
+
+type XDGSCRAMClient struct {
+	*scram.Client
+	*scram.ClientConversation
+	scram.HashGeneratorFcn
+}
+
+func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
+	x.Client, err = x.HashGeneratorFcn.NewClient(userName, password, authzID)
+	if err != nil {
+		return err
+	}
+	x.ClientConversation = x.Client.NewConversation()
+	return nil
+}
+
+func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
+	response, err = x.ClientConversation.Step(challenge)
+	return
+}
+
+func (x *XDGSCRAMClient) Done() bool {
+	return x.ClientConversation.Done()
+}

--- a/core/internal/helpers/storage.go
+++ b/core/internal/helpers/storage.go
@@ -13,7 +13,7 @@ package helpers
 import (
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // TimeoutSendStorageRequest is a helper func for sending a protocol.StorageRequest to a channel with a timeout,

--- a/core/internal/helpers/storage_test.go
+++ b/core/internal/helpers/storage_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func TestTimeoutSendStorageRequest(t *testing.T) {

--- a/core/internal/helpers/zookeeper.go
+++ b/core/internal/helpers/zookeeper.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // BurrowZookeeperClient is an implementation of protocol.ZookeeperClient
@@ -120,6 +120,11 @@ func (z *BurrowZookeeperClient) GetW(path string) ([]byte, *zk.Stat, <-chan zk.E
 	return z.client.GetW(path)
 }
 
+// Exists returns a boolean stating whether or not the specified path exists.
+func (z *BurrowZookeeperClient) Exists(path string) (bool, *zk.Stat, error) {
+	return z.client.Exists(path)
+}
+
 // ExistsW returns a boolean stating whether or not the specified path exists. This method also sets a watch on the node
 // (exists if it does not currently exist, or a data watch otherwise), providing an event channel that will receive a
 // message when the watch fires
@@ -177,6 +182,12 @@ func (m *MockZookeeperClient) ChildrenW(path string) ([]string, *zk.Stat, <-chan
 func (m *MockZookeeperClient) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
 	args := m.Called(path)
 	return args.Get(0).([]byte), args.Get(1).(*zk.Stat), args.Get(2).(<-chan zk.Event), args.Error(3)
+}
+
+// Exists mocks protocol.ZookeeperClient.Exists
+func (m *MockZookeeperClient) Exists(path string) (bool, *zk.Stat, error) {
+	args := m.Called(path)
+	return args.Bool(0), args.Get(1).(*zk.Stat), args.Error(2)
 }
 
 // ExistsW mocks protocol.ZookeeperClient.ExistsW

--- a/core/internal/helpers/zookeeper_test.go
+++ b/core/internal/helpers/zookeeper_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func TestBurrowZookeeperClient_ImplementsZookeeperClient(t *testing.T) {

--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -11,7 +11,7 @@
 // Package httpserver - HTTP API endpoint
 // The httpserver subsystem provides an HTTP interface to Burrow that can be used to fetch information about the
 // clusters and consumers it is monitoring. More documentation on the requests and responses is provided at
-// https://github.com/linkedin/Burrow/wiki/HTTP-Endpoint.
+// https://github.com/yext/Burrow/wiki/HTTP-Endpoint.
 package httpserver
 
 import (
@@ -31,8 +31,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // Coordinator runs the HTTP interface for Burrow, managing all configured listeners.

--- a/core/internal/httpserver/coordinator_test.go
+++ b/core/internal/httpserver/coordinator_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureConfiguredCoordinator() *Coordinator {

--- a/core/internal/httpserver/kafka.go
+++ b/core/internal/httpserver/kafka.go
@@ -16,7 +16,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/spf13/viper"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func (hc *Coordinator) handleClusterList(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/core/internal/httpserver/kafka_test.go
+++ b/core/internal/httpserver/kafka_test.go
@@ -21,7 +21,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func TestHttpServer_handleClusterList(t *testing.T) {

--- a/core/internal/httpserver/structs.go
+++ b/core/internal/httpserver/structs.go
@@ -10,7 +10,7 @@
 
 package httpserver
 
-import "github.com/linkedin/Burrow/core/protocol"
+import "github.com/yext/Burrow/core/protocol"
 
 type logLevelRequest struct {
 	Level string `json:"level"`

--- a/core/internal/notifier/coordinator.go
+++ b/core/internal/notifier/coordinator.go
@@ -38,8 +38,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // Module defines a means of sending out notifications of consumer group status (such as email), as well as regular

--- a/core/internal/notifier/coordinator_race_test.go
+++ b/core/internal/notifier/coordinator_race_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/internal/helpers"
 )
 
 // This tests the full set of calls to send evaluator requests. It triggers the race detector because of setting

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/notifier/email.go
+++ b/core/internal/notifier/email.go
@@ -24,8 +24,8 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/gomail.v2"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // EmailNotifier is a module which can be used to send notifications of consumer group status via email messages. One

--- a/core/internal/notifier/email_test.go
+++ b/core/internal/notifier/email_test.go
@@ -11,22 +11,19 @@
 package notifier
 
 import (
-	"text/template"
-	"time"
-
-	"testing"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
 	"net"
 	"strconv"
+	"text/template"
+	"time"
+	"testing"
+
+	"go.uber.org/zap"
 
 	"gopkg.in/gomail.v2"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/spf13/viper"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureEmailNotifier() *EmailNotifier {

--- a/core/internal/notifier/helpers.go
+++ b/core/internal/notifier/helpers.go
@@ -20,7 +20,7 @@ import (
 
 	"bytes"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // executeTemplate provides a common interface for notifier modules to call to process a text/template in the context

--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -25,7 +25,7 @@ import (
 
 	"crypto/tls"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // HTTPNotifier is a module which can be used to send notifications of consumer group status via outbound HTTP calls to

--- a/core/internal/notifier/http_test.go
+++ b/core/internal/notifier/http_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureHTTPNotifier() *HTTPNotifier {

--- a/core/internal/notifier/null.go
+++ b/core/internal/notifier/null.go
@@ -17,7 +17,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // NullNotifier is a no-op notifier that can be used for testing purposes in place of a mock. It does not make any

--- a/core/internal/storage/coordinator.go
+++ b/core/internal/storage/coordinator.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // Module (storage) is responsible for maintaining all the broker and consumer offsets for all clusters that Burrow

--- a/core/internal/storage/coordinator_test.go
+++ b/core/internal/storage/coordinator_test.go
@@ -11,16 +11,14 @@
 package storage
 
 import (
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
-
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-
 	"time"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"go.uber.org/zap"
+	
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/internal/storage/fixtures.go
+++ b/core/internal/storage/fixtures.go
@@ -16,7 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // CoordinatorWithOffsets sets up a Coordinator with a single inmemory module defined. This module is loaded with

--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 // InMemoryStorage is a storage module that maintains the entire data set in memory in a series of maps. It has a

--- a/core/internal/storage/inmemory_test.go
+++ b/core/internal/storage/inmemory_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureModule(whitelist, blacklist string) *InMemoryStorage {

--- a/core/internal/zookeeper/coordinator_test.go
+++ b/core/internal/zookeeper/coordinator_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 
-	"github.com/linkedin/Burrow/core/internal/helpers"
-	"github.com/linkedin/Burrow/core/protocol"
+	"github.com/yext/Burrow/core/internal/helpers"
+	"github.com/yext/Burrow/core/protocol"
 )
 
 func fixtureCoordinator() *Coordinator {

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -141,13 +141,17 @@ type ZookeeperClient interface {
 	// the children of the specified path, providing an event channel that will receive a message when the watch fires
 	GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error)
 
+	// For the given path in Zookeeper, return a boolean stating whether or not the node exists.
+	// The method does not set watch on the node, but verifies existence of a node to avoid authentication error.
+	Exists(path string) (bool, *zk.Stat, error)
+
 	// For the given path in Zookeeper, return a boolean stating whether or not the node exists. This method also sets
 	// a watch on the node (exists if it does not currently exist, or a data watch otherwise), providing an event
 	// channel that will receive a message when the watch fires
 	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
 
 	// Create makes a new ZNode at the specified path with the contents set to the data byte-slice. Flags can be
-	// provided to specify that this is an ephemeral or sequence node, and an ACL must be provided. If no ACL is\
+	// provided to specify that this is an ephemeral or sequence node, and an ACL must be provided. If no ACL is
 	// desired, specify
 	//  zk.WorldACL(zk.PermAll)
 	Create(string, []byte, int32, []zk.ACL) (string, error)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/linkedin/Burrow
+module github.com/yext/Burrow
 
 require (
 	github.com/OneOfOne/xxhash v1.2.7
@@ -28,6 +28,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
+	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c
 	go.uber.org/atomic v1.5.1 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -190,7 +190,9 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c h1:u40Z8hqBAAQyv+vATcGgV0YCnDjqSL7/q/JyPhhJSPk=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
+github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/linkedin/Burrow/core"
+	"github.com/yext/Burrow/core"
 )
 
 // exitCode wraps a return value for the application


### PR DESCRIPTION
This includes:

1. Add SASL-SCRAM ability to Kafka connection

This PR adds the ability to connect to Kafka via SASL-SCRAM 256 or 512

It adds an entry in the SASL Profile configuration called
key=mechanism
value type=string
required=no
default value=(empty)
Which accepts either values SCRAM-SHA-256, SCRAM-SHA-512

Partially addresses #526

2. Ignore ZooKeeper znode Create if the path already exists

Currently, Burrow will attempt to create the znode used by Burrow on startup
This will cause problems if there is authentication needed when connecting
to zk.

The fix is to ignore creating zk node paths if it already exists

3. Yext specific Dockerfile

the config file and dir used by Burrow is updated for M4 and Khan

4. Update module and import references

go build -o build/Burrow github.com/yext/Burrow
pulls in linkedin's branch of Burrow

Changing references of linkedin to current fork