### PR TITLE
Change configuration names to allowlist and denylist

### DIFF
--- a/config/burrow.toml
+++ b/config/burrow.toml
@@ -33,8 +33,8 @@ class-name="kafka"
 cluster="local"
 servers=[ "kafka01.example.com:10251", "kafka02.example.com:10251", "kafka03.example.com:10251" ]
 client-profile="test"
-group-blacklist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
-group-whitelist=""
+group-denylist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
+group-allowlist=""
 
 [consumer.local_zk]
 class-name="kafka_zk"
@@ -42,8 +42,8 @@ cluster="local"
 servers=[ "zk01.example.com:2181", "zk02.example.com:2181", "zk03.example.com:2181" ]
 zookeeper-path="/kafka-cluster"
 zookeeper-timeout=30
-group-blacklist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
-group-whitelist=""
+group-denylist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
+group-allowlist=""
 
 [httpserver.default]
 address=":8000"

--- a/core/internal/consumer/kafka_client_test.go
+++ b/core/internal/consumer/kafka_client_test.go
@@ -81,7 +81,7 @@ func TestKafkaClient_Configure_BadCluster(t *testing.T) {
 
 func TestKafkaClient_Configure_BadRegexp(t *testing.T) {
 	module := fixtureModule()
-	viper.Set("consumer.test.group-whitelist", "[")
+	viper.Set("consumer.test.group-allowlist", "[")
 	assert.Panics(t, func() { module.Configure("test", "consumer.test") }, "The code did not panic")
 }
 
@@ -511,7 +511,7 @@ func TestKafkaClient_decodeOffsetValueV3_Errors(t *testing.T) {
 
 func TestKafkaClient_decodeKeyAndOffset(t *testing.T) {
 	module := fixtureModule()
-	viper.Set("consumer.test.group-whitelist", "test.*")
+	viper.Set("consumer.test.group-allowlist", "test.*")
 	module.Configure("test", "consumer.test")
 
 	keyBuf := bytes.NewBuffer([]byte("\x00\x09testgroup\x00\x09testtopic\x00\x00\x00\x0b"))
@@ -546,15 +546,15 @@ func TestKafkaClient_decodeKeyAndOffset_BadValueVersion(t *testing.T) {
 	}
 }
 
-func TestKafkaClient_decodeKeyAndOffset_Whitelist(t *testing.T) {
+func TestKafkaClient_decodeKeyAndOffset_Allowlist(t *testing.T) {
 	module := fixtureModule()
-	viper.Set("consumer.test.group-whitelist", "test.*")
+	viper.Set("consumer.test.group-allowlist", "test.*")
 	module.Configure("test", "consumer.test")
 
 	keyBuf := bytes.NewBuffer([]byte("\x00\x0ddropthisgroup\x00\x09testtopic\x00\x00\x00\x0b"))
 	valueBytes := []byte("\x00\x00\x00\x00\x00\x00\x00\x00\x20\xb4\x00\x08testdata\x00\x00\x00\x00\x00\x00\x06\x65")
 
-	// Should not timeout as the group should be dropped by the whitelist
+	// Should not timeout as the group should be dropped by the allowlist
 	module.decodeKeyAndOffset(0, keyBuf, valueBytes, zap.NewNop())
 }
 

--- a/core/internal/consumer/kafka_zk_test.go
+++ b/core/internal/consumer/kafka_zk_test.go
@@ -61,7 +61,7 @@ func TestKafkaZkClient_Configure(t *testing.T) {
 
 func TestKafkaZkClient_Configure_BadRegexp(t *testing.T) {
 	module := fixtureModule()
-	viper.Set("consumer.test.group-whitelist", "[")
+	viper.Set("consumer.test.group-allowlist", "[")
 	assert.Panics(t, func() { module.Configure("test", "consumer.test") }, "The code did not panic")
 }
 
@@ -100,7 +100,7 @@ func TestKafkaZkClient_watchGroupList(t *testing.T) {
 	mockZookeeper := helpers.MockZookeeperClient{}
 
 	module := fixtureKafkaZkModule()
-	viper.Set("consumer.test.group-whitelist", "test.*")
+	viper.Set("consumer.test.group-allowlist", "test.*")
 	module.Configure("test", "consumer.test")
 	module.zk = &mockZookeeper
 
@@ -263,11 +263,11 @@ func TestKafkaZkClient_resetGroupListWatchAndAdd_BadPath(t *testing.T) {
 	mockZookeeper.AssertExpectations(t)
 }
 
-func TestKafkaZkClient_resetGroupListWatchAndAdd_WhiteList(t *testing.T) {
+func TestKafkaZkClient_resetGroupListWatchAndAdd_AllowList(t *testing.T) {
 	mockZookeeper := helpers.MockZookeeperClient{}
 
 	module := fixtureKafkaZkModule()
-	viper.Set("consumer.test.group-whitelist", "test.*")
+	viper.Set("consumer.test.group-allowlist", "test.*")
 	module.Configure("test", "consumer.test")
 	module.zk = &mockZookeeper
 
@@ -286,5 +286,5 @@ func TestKafkaZkClient_resetGroupListWatchAndAdd_WhiteList(t *testing.T) {
 
 	mockZookeeper.AssertExpectations(t)
 	_, ok := module.groupList["dropthisgroup"]
-	assert.False(t, ok, "Expected group to be dropped due to whitelist")
+	assert.False(t, ok, "Expected group to be dropped due to allowlist")
 }

--- a/core/internal/helpers/coordinators.go
+++ b/core/internal/helpers/coordinators.go
@@ -75,14 +75,14 @@ func (m *MockModule) GetName() string {
 	return args.String(0)
 }
 
-// GetGroupWhitelist mocks the notifier.Module GetGroupWhitelist func
-func (m *MockModule) GetGroupWhitelist() *regexp.Regexp {
+// GetGroupAllowlist mocks the notifier.Module GetGroupAllowlist func
+func (m *MockModule) GetGroupAllowlist() *regexp.Regexp {
 	args := m.Called()
 	return args.Get(0).(*regexp.Regexp)
 }
 
-// GetGroupBlacklist mocks the notifier.Module GetGroupBlacklist func
-func (m *MockModule) GetGroupBlacklist() *regexp.Regexp {
+// GetGroupDenylist mocks the notifier.Module GetGroupDenylist func
+func (m *MockModule) GetGroupDenylist() *regexp.Regexp {
 	args := m.Called()
 	return args.Get(0).(*regexp.Regexp)
 }

--- a/core/internal/httpserver/config.go
+++ b/core/internal/httpserver/config.go
@@ -141,7 +141,7 @@ func (hc *Coordinator) configStorageDetail(w http.ResponseWriter, r *http.Reques
 				ClassName:      viper.GetString(configRoot + ".class-name"),
 				Intervals:      viper.GetInt(configRoot + ".intervals"),
 				MinDistance:    viper.GetInt64(configRoot + ".min-distance"),
-				GroupWhitelist: viper.GetString(configRoot + ".group-whitelist"),
+				GroupAllowlist: viper.GetString(configRoot + ".group-allowlist"),
 				ExpireGroup:    viper.GetInt64(configRoot + ".expire-group"),
 			},
 			Request: requestInfo,
@@ -162,7 +162,7 @@ func (hc *Coordinator) configConsumerDetail(w http.ResponseWriter, r *http.Reque
 				ClassName:        viper.GetString(configRoot + ".class-name"),
 				Cluster:          viper.GetString(configRoot + ".cluster"),
 				Servers:          viper.GetStringSlice(configRoot + ".servers"),
-				GroupWhitelist:   viper.GetString(configRoot + ".group-whitelist"),
+				GroupAllowlist:   viper.GetString(configRoot + ".group-allowlist"),
 				ZookeeperPath:    viper.GetString(configRoot + ".zookeeper-path"),
 				ZookeeperTimeout: int32(viper.GetInt64(configRoot + ".zookeeper-timeout")),
 				ClientProfile:    getClientProfile(viper.GetString(configRoot + ".client-profile")),
@@ -199,7 +199,7 @@ func (hc *Coordinator) configNotifierHTTP(w http.ResponseWriter, r *http.Request
 		Message: "notifier module detail returned",
 		Module: httpResponseConfigModuleNotifierHTTP{
 			ClassName:      viper.GetString(configRoot + ".class-name"),
-			GroupWhitelist: viper.GetString(configRoot + ".group-whitelist"),
+			GroupAllowlist: viper.GetString(configRoot + ".group-allowlist"),
 			Interval:       viper.GetInt64(configRoot + ".interval"),
 			Threshold:      viper.GetInt(configRoot + ".threshold"),
 			Timeout:        viper.GetInt(configRoot + ".timeout"),
@@ -226,7 +226,7 @@ func (hc *Coordinator) configNotifierSlack(w http.ResponseWriter, r *http.Reques
 		Message: "notifier module detail returned",
 		Module: httpResponseConfigModuleNotifierSlack{
 			ClassName:      viper.GetString(configRoot + ".class-name"),
-			GroupWhitelist: viper.GetString(configRoot + ".group-whitelist"),
+			GroupAllowlist: viper.GetString(configRoot + ".group-allowlist"),
 			Interval:       viper.GetInt64(configRoot + ".interval"),
 			Threshold:      viper.GetInt(configRoot + ".threshold"),
 			Timeout:        viper.GetInt(configRoot + ".timeout"),
@@ -251,7 +251,7 @@ func (hc *Coordinator) configNotifierEmail(w http.ResponseWriter, r *http.Reques
 		Message: "notifier module detail returned",
 		Module: httpResponseConfigModuleNotifierEmail{
 			ClassName:      viper.GetString(configRoot + ".class-name"),
-			GroupWhitelist: viper.GetString(configRoot + ".group-whitelist"),
+			GroupAllowlist: viper.GetString(configRoot + ".group-allowlist"),
 			Interval:       viper.GetInt64(configRoot + ".interval"),
 			Threshold:      viper.GetInt(configRoot + ".threshold"),
 			TemplateOpen:   viper.GetString(configRoot + ".template-open"),
@@ -278,7 +278,7 @@ func (hc *Coordinator) configNotifierNull(w http.ResponseWriter, r *http.Request
 		Message: "notifier module detail returned",
 		Module: httpResponseConfigModuleNotifierNull{
 			ClassName:      viper.GetString(configRoot + ".class-name"),
-			GroupWhitelist: viper.GetString(configRoot + ".group-whitelist"),
+			GroupAllowlist: viper.GetString(configRoot + ".group-allowlist"),
 			Interval:       viper.GetInt64(configRoot + ".interval"),
 			Threshold:      viper.GetInt(configRoot + ".threshold"),
 			TemplateOpen:   viper.GetString(configRoot + ".template-open"),

--- a/core/internal/httpserver/structs.go
+++ b/core/internal/httpserver/structs.go
@@ -157,7 +157,7 @@ type httpResponseConfigModuleStorage struct {
 	ClassName      string `json:"class-name"`
 	Intervals      int    `json:"intervals"`
 	MinDistance    int64  `json:"min-distance"`
-	GroupWhitelist string `json:"group-whitelist"`
+	GroupAllowlist string `json:"group-allowlist"`
 	ExpireGroup    int64  `json:"expire-group"`
 }
 
@@ -173,7 +173,7 @@ type httpResponseConfigModuleConsumer struct {
 	ClassName        string                    `json:"class-name"`
 	Cluster          string                    `json:"cluster"`
 	Servers          []string                  `json:"servers"`
-	GroupWhitelist   string                    `json:"group-whitelist"`
+	GroupAllowlist   string                    `json:"group-allowlist"`
 	ZookeeperPath    string                    `json:"zookeeper-path"`
 	ZookeeperTimeout int32                     `json:"zookeeper-timeout"`
 	ClientProfile    httpResponseClientProfile `json:"client-profile"`
@@ -188,7 +188,7 @@ type httpResponseConfigModuleEvaluator struct {
 
 type httpResponseConfigModuleNotifierHTTP struct {
 	ClassName      string            `json:"class-name"`
-	GroupWhitelist string            `json:"group-whitelist"`
+	GroupAllowlist string            `json:"group-allowlist"`
 	Interval       int64             `json:"interval"`
 	Threshold      int               `json:"threshold"`
 	Timeout        int               `json:"timeout"`
@@ -207,7 +207,7 @@ type httpResponseConfigModuleNotifierHTTP struct {
 
 type httpResponseConfigModuleNotifierSlack struct {
 	ClassName      string            `json:"class-name"`
-	GroupWhitelist string            `json:"group-whitelist"`
+	GroupAllowlist string            `json:"group-allowlist"`
 	Interval       int64             `json:"interval"`
 	Threshold      int               `json:"threshold"`
 	Timeout        int               `json:"timeout"`
@@ -224,7 +224,7 @@ type httpResponseConfigModuleNotifierSlack struct {
 
 type httpResponseConfigModuleNotifierEmail struct {
 	ClassName      string            `json:"class-name"`
-	GroupWhitelist string            `json:"group-whitelist"`
+	GroupAllowlist string            `json:"group-allowlist"`
 	Interval       int64             `json:"interval"`
 	Threshold      int               `json:"threshold"`
 	TemplateOpen   string            `json:"template-open"`
@@ -243,7 +243,7 @@ type httpResponseConfigModuleNotifierEmail struct {
 
 type httpResponseConfigModuleNotifierNull struct {
 	ClassName      string            `json:"class-name"`
-	GroupWhitelist string            `json:"group-whitelist"`
+	GroupAllowlist string            `json:"group-allowlist"`
 	Interval       int64             `json:"interval"`
 	Threshold      int               `json:"threshold"`
 	TemplateOpen   string            `json:"template-open"`

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -19,8 +19,6 @@ import (
 	"text/template"
 	"time"
 
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
@@ -52,7 +50,7 @@ func fixtureCoordinator() *Coordinator {
 
 	viper.Reset()
 	viper.Set("notifier.test.class-name", "null")
-	viper.Set("notifier.test.group-whitelist", ".*")
+	viper.Set("notifier.test.group-allowlist", ".*")
 	viper.Set("notifier.test.threshold", 1)
 	viper.Set("notifier.test.interval", 5)
 	viper.Set("notifier.test.timeout", 2)
@@ -107,7 +105,7 @@ func TestCoordinator_Configure_TwoModules(t *testing.T) {
 
 func TestCoordinator_Configure_BadRegexp(t *testing.T) {
 	coordinator := fixtureCoordinator()
-	viper.Set("notifier.test.group-whitelist", "[")
+	viper.Set("notifier.test.group-allowlist", "[")
 
 	assert.Panics(t, func() { coordinator.Configure() }, "The code did not panic")
 }
@@ -565,8 +563,8 @@ func TestCoordinator_checkAndSendResponseToModules(t *testing.T) {
 		mockModule := &helpers.MockModule{}
 		coordinator.modules["test"] = mockModule
 		mockModule.On("GetName").Return("test")
-		mockModule.On("GetGroupWhitelist").Return((*regexp.Regexp)(nil))
-		mockModule.On("GetGroupBlacklist").Return((*regexp.Regexp)(nil))
+		mockModule.On("GetGroupAllowlist").Return((*regexp.Regexp)(nil))
+		mockModule.On("GetGroupDenylist").Return((*regexp.Regexp)(nil))
 		mockModule.On("AcceptConsumerGroup", response).Return(true)
 		if testSet.ExpectSend {
 			mockModule.On("Notify", response, mock.MatchedBy(func(s string) bool { return true }), mock.MatchedBy(func(t time.Time) bool { return true }), testSet.ExpectClose).Return()

--- a/core/internal/notifier/email.go
+++ b/core/internal/notifier/email.go
@@ -29,7 +29,7 @@ import (
 )
 
 // EmailNotifier is a module which can be used to send notifications of consumer group status via email messages. One
-// email is sent for each consumer group that matches the whitelist/blacklist and the status threshold.
+// email is sent for each consumer group that matches the allowlist/denylist and the status threshold.
 type EmailNotifier struct {
 	// App is a pointer to the application context. This stores the channel to the storage subsystem
 	App *protocol.ApplicationContext
@@ -39,8 +39,8 @@ type EmailNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	groupWhitelist *regexp.Regexp
-	groupBlacklist *regexp.Regexp
+	groupAllowlist *regexp.Regexp
+	groupDenylist  *regexp.Regexp
 	extras         map[string]string
 	templateOpen   *template.Template
 	templateClose  *template.Template
@@ -140,14 +140,14 @@ func (module *EmailNotifier) GetName() string {
 	return module.name
 }
 
-// GetGroupWhitelist returns the compiled group whitelist (or nil, if there is not one)
-func (module *EmailNotifier) GetGroupWhitelist() *regexp.Regexp {
-	return module.groupWhitelist
+// GetGroupAllowlist returns the compiled group allowlist (or nil, if there is not one)
+func (module *EmailNotifier) GetGroupAllowlist() *regexp.Regexp {
+	return module.groupAllowlist
 }
 
-// GetGroupBlacklist returns the compiled group blacklist (or nil, if there is not one)
-func (module *EmailNotifier) GetGroupBlacklist() *regexp.Regexp {
-	return module.groupBlacklist
+// GetGroupDenylist returns the compiled group denylist (or nil, if there is not one)
+func (module *EmailNotifier) GetGroupDenylist() *regexp.Regexp {
+	return module.groupDenylist
 }
 
 // GetLogger returns the configured zap.Logger for this notifier

--- a/core/internal/notifier/http.go
+++ b/core/internal/notifier/http.go
@@ -30,7 +30,7 @@ import (
 
 // HTTPNotifier is a module which can be used to send notifications of consumer group status via outbound HTTP calls to
 // another server. This is useful for informing another system, such as an alert system, when there is a problem. One
-// HTTP call is made for each consumer group that matches the whitelist/blacklist and the status threshold (though
+// HTTP call is made for each consumer group that matches the allowlist/denylist and the status threshold (though
 // keepalive connections will be used if configured).
 type HTTPNotifier struct {
 	// App is a pointer to the application context. This stores the channel to the storage subsystem
@@ -41,8 +41,8 @@ type HTTPNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	groupWhitelist *regexp.Regexp
-	groupBlacklist *regexp.Regexp
+	groupAllowlist *regexp.Regexp
+	groupDenylist  *regexp.Regexp
 	extras         map[string]string
 	urlOpen        string
 	urlClose       string
@@ -126,14 +126,14 @@ func (module *HTTPNotifier) GetName() string {
 	return module.name
 }
 
-// GetGroupWhitelist returns the compiled group whitelist (or nil, if there is not one)
-func (module *HTTPNotifier) GetGroupWhitelist() *regexp.Regexp {
-	return module.groupWhitelist
+// GetGroupAllowlist returns the compiled group allowlist (or nil, if there is not one)
+func (module *HTTPNotifier) GetGroupAllowlist() *regexp.Regexp {
+	return module.groupAllowlist
 }
 
-// GetGroupBlacklist returns the compiled group blacklist (or nil, if there is not one)
-func (module *HTTPNotifier) GetGroupBlacklist() *regexp.Regexp {
-	return module.groupBlacklist
+// GetGroupDenylist returns the compiled group denylist (or nil, if there is not one)
+func (module *HTTPNotifier) GetGroupDenylist() *regexp.Regexp {
+	return module.groupDenylist
 }
 
 // GetLogger returns the configured zap.Logger for this notifier

--- a/core/internal/notifier/null.go
+++ b/core/internal/notifier/null.go
@@ -31,8 +31,8 @@ type NullNotifier struct {
 	Log *zap.Logger
 
 	name           string
-	groupWhitelist *regexp.Regexp
-	groupBlacklist *regexp.Regexp
+	groupAllowlist *regexp.Regexp
+	groupDenylist  *regexp.Regexp
 	extras         map[string]string
 	templateOpen   *template.Template
 	templateClose  *template.Template
@@ -76,14 +76,14 @@ func (module *NullNotifier) GetName() string {
 	return module.name
 }
 
-// GetGroupWhitelist returns the compiled group whitelist (or nil, if there is not one)
-func (module *NullNotifier) GetGroupWhitelist() *regexp.Regexp {
-	return module.groupWhitelist
+// GetGroupAllowlist returns the compiled group allowlist (or nil, if there is not one)
+func (module *NullNotifier) GetGroupAllowlist() *regexp.Regexp {
+	return module.groupAllowlist
 }
 
-// GetGroupBlacklist returns the compiled group blacklist (or nil, if there is not one)
-func (module *NullNotifier) GetGroupBlacklist() *regexp.Regexp {
-	return module.groupBlacklist
+// GetGroupDenylist returns the compiled group denylist (or nil, if there is not one)
+func (module *NullNotifier) GetGroupDenylist() *regexp.Regexp {
+	return module.groupDenylist
 }
 
 // GetLogger returns the configured zap.Logger for this notifier

--- a/core/internal/storage/fixtures.go
+++ b/core/internal/storage/fixtures.go
@@ -35,7 +35,7 @@ func CoordinatorWithOffsets() *Coordinator {
 	viper.Set("storage.test.class-name", "inmemory")
 	viper.Set("storage.test.intervals", 10)
 	viper.Set("storage.test.min-distance", 0)
-	viper.Set("storage.test.group-whitelist", "")
+	viper.Set("storage.test.group-allowlist", "")
 	viper.Set("cluster.testcluster.class-name", "kafka")
 
 	coordinator.Configure()

--- a/docker-config/burrow.toml
+++ b/docker-config/burrow.toml
@@ -13,8 +13,8 @@ offset-refresh=30
 class-name="kafka"
 cluster="local"
 servers=[ "kafka:9092" ]
-group-blacklist="^(console-consumer-|python-kafka-consumer-).*$"
-group-whitelist=""
+group-denylist="^(console-consumer-|python-kafka-consumer-).*$"
+group-allowlist=""
 
 [consumer.local_zk]
 class-name="kafka_zk"
@@ -22,8 +22,8 @@ cluster="local"
 servers=[ "zookeeper:2181" ]
 zookeeper-path="/local"
 zookeeper-timeout=30
-group-blacklist="^(console-consumer-|python-kafka-consumer-).*$"
-group-whitelist=""
+group-denylist="^(console-consumer-|python-kafka-consumer-).*$"
+group-allowlist=""
 
 [httpserver.default]
 address=":8000"


### PR DESCRIPTION
This updates the Burrow codebase to use better language:

"whitelist" becomes "allowlist"
"blacklist" becomes "denylist"

This is implemented as a breaking change. If the old names are used in a configuration, an error message is output and the application stops. This check is necessary to maintain in the code because otherwise we would just silently ignore the old configurations, which is not intended behavior.