### PR TITLE
add a groups reaper to remove non existing groups

### DIFF
--- a/config/burrow.toml
+++ b/config/burrow.toml
@@ -27,6 +27,7 @@ servers=[ "kafka01.example.com:10251", "kafka02.example.com:10251", "kafka03.exa
 client-profile="test"
 topic-refresh=120
 offset-refresh=30
+groups-reaper-refresh=0
 
 [consumer.local]
 class-name="kafka"

--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -303,7 +303,8 @@ func (module *KafkaCluster) getOffsets(client helpers.SaramaClient) {
 func (module *KafkaCluster) reapNonExistingGroups(client helpers.SaramaClient) {
 	kafkaGroups, err := client.ListConsumerGroups()
 	if err != nil {
-		module.Log.Warn("failed to get the list of available consumer groups", zap.Error(err))
+		module.Log.Error("failed to get the list of available consumer groups", zap.Error(err))
+		return
 	}
 
 	req := &protocol.StorageRequest{

--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -324,7 +324,10 @@ func (module *KafkaCluster) reapNonExistingGroups(client helpers.SaramaClient) {
 	burrowIgnoreGroupName := "burrow-" + module.name
 	burrowGroups, _ := res.([]string)
 	for _, g := range burrowGroups {
-		if _, ok := kafkaGroups[g]; !ok && g != burrowIgnoreGroupName {
+		if g == burrowIgnoreGroupName {
+			continue
+		}
+		if _, ok := kafkaGroups[g]; !ok {
 			module.Log.Info(fmt.Sprintf("groups reaper: removing non existing kafka consumer group (%s) from burrow", g))
 			request := &protocol.StorageRequest{
 				RequestType: protocol.StorageSetDeleteGroup,

--- a/core/internal/cluster/kafka_cluster_test.go
+++ b/core/internal/cluster/kafka_cluster_test.go
@@ -286,6 +286,7 @@ func TestKafkaCluster_reapNonExistingGroups(t *testing.T) {
 	module := fixtureModule()
 	module.Configure("test", "cluster.test")
 
+	// only group1 exists in kafka
 	client := &helpers.MockSaramaClient{}
 	client.On("ListConsumerGroups").Return(map[string]string{"group1": ""}, nil)
 
@@ -296,8 +297,10 @@ func TestKafkaCluster_reapNonExistingGroups(t *testing.T) {
 	assert.Equalf(t, protocol.StorageFetchConsumers, request.RequestType, "Expected request sent with type StorageFetchConsumers, not %v", request.RequestType)
 	assert.Equalf(t, "test", request.Cluster, "Expected request sent with cluster test, not %v", request.Cluster)
 
+	// burrow have group1, and group2, kafka only knows about group1, so group2 will be deleted by the reaper
 	request.Reply <- []string{"group1", "group2"}
 	request = <-module.App.StorageChannel
+
 	assert.Equalf(t, protocol.StorageSetDeleteGroup, request.RequestType, "Expected request sent with type StorageFetchConsumers, not %v", request.RequestType)
 	assert.Equalf(t, "test", request.Cluster, "Expected request sent with cluster test, not %v", request.Cluster)
 	assert.Equalf(t, "group2", request.Group, "Expected request sent with group group2, not %v", request.Group)

--- a/core/internal/cluster/kafka_cluster_test.go
+++ b/core/internal/cluster/kafka_cluster_test.go
@@ -37,9 +37,10 @@ func fixtureModule() *KafkaCluster {
 	}
 
 	viper.Reset()
-	viper.Set("client-profile..client-id", "testid")
+	viper.Set("client-profile.p1.client-id", "testid")
 	viper.Set("cluster.test.class-name", "kafka")
 	viper.Set("cluster.test.servers", []string{"broker1.example.com:1234"})
+	viper.Set("cluster.test.client-profile", "p1")
 
 	return &module
 }

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -205,6 +205,9 @@ type SaramaClient interface {
 	// NewConsumerFromClient creates a new consumer using the given client. It is still necessary to call Close() on the
 	// underlying client when shutting down this consumer.
 	NewConsumerFromClient() (sarama.Consumer, error)
+
+	// List the consumer groups available in the cluster.
+	ListConsumerGroups() (map[string]string, error)
 }
 
 // BurrowSaramaClient is an implementation of the SaramaClient interface for use in Burrow modules
@@ -349,6 +352,19 @@ func (b *BurrowSaramaBroker) GetAvailableOffsets(request *sarama.OffsetRequest) 
 	return b.broker.GetAvailableOffsets(request)
 }
 
+// ListConsumerGroups List the consumer groups available in the cluster.
+func (c *BurrowSaramaClient) ListConsumerGroups() (map[string]string, error) {
+	admin, err := sarama.NewClusterAdminFromClient(c.Client)
+	if err != nil {
+		return nil, err
+	}
+	groups, err := admin.ListConsumerGroups()
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
 // MockSaramaClient is a mock of SaramaClient. It is used in tests by multiple packages. It should never be used in the
 // normal code.
 type MockSaramaClient struct {
@@ -448,6 +464,11 @@ func (m *MockSaramaClient) Closed() bool {
 func (m *MockSaramaClient) NewConsumerFromClient() (sarama.Consumer, error) {
 	args := m.Called()
 	return args.Get(0).(sarama.Consumer), args.Error(1)
+}
+
+func (m *MockSaramaClient) ListConsumerGroups() (map[string]string, error) {
+	args := m.Called()
+	return args.Get(0).(map[string]string), args.Error(1)
 }
 
 // MockSaramaBroker is a mock of SaramaBroker. It is used in tests by multiple packages. It should never be used in the

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -207,6 +207,9 @@ type SaramaClient interface {
 	NewConsumerFromClient() (sarama.Consumer, error)
 
 	// List the consumer groups available in the cluster.
+	// Returns a Map with the consumer group and consumer group type, this is
+	// used in the code as a Set, the consumer group type is not relevant, we
+	// decided to not convert it to a map[string]struct returned by Sarama
 	ListConsumerGroups() (map[string]string, error)
 }
 
@@ -358,11 +361,7 @@ func (c *BurrowSaramaClient) ListConsumerGroups() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	groups, err := admin.ListConsumerGroups()
-	if err != nil {
-		return nil, err
-	}
-	return groups, nil
+	return admin.ListConsumerGroups()
 }
 
 // MockSaramaClient is a mock of SaramaClient. It is used in tests by multiple packages. It should never be used in the

--- a/core/internal/notifier/coordinator_test.go
+++ b/core/internal/notifier/coordinator_test.go
@@ -166,9 +166,6 @@ func TestCoordinator_sendClusterRequest(t *testing.T) {
 	coordinator := fixtureCoordinator()
 	coordinator.Configure()
 
-	// This cluster will get deleted
-	coordinator.clusters["deleteme"] = &clusterGroups{}
-
 	// This goroutine will receive the storage request for a cluster list, and respond with an appropriate list
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/docker-config/burrow.toml
+++ b/docker-config/burrow.toml
@@ -3,11 +3,17 @@ servers=[ "zookeeper:2181" ]
 timeout=6
 root-path="/burrow"
 
+[client-profile.profile]
+kafka-version="0.11.0"
+client-id="docker-client"
+
 [cluster.local]
+client-profile="profile"
 class-name="kafka"
 servers=[ "kafka:9092" ]
 topic-refresh=60
 offset-refresh=30
+groups-reaper-refresh=30
 
 [consumer.local]
 class-name="kafka"


### PR DESCRIPTION
burrow currently keeps reporting lag for non-existing consumers.

The only way to remove groups from burrow automatically is configuring
`expire-group`, which is not ideal as it can conflict with consumer with
no members.

This PR introduces a go routine to get the existing consumer groups from
Kafka, and compare it against burrow consumers to reap the non-existing ones.


🎩 

```
╰─○ curl localhost:8000/v3/kafka/local/consumer
{"error":false,"message":"consumer list returned","consumers":["burrow-local"],"request":{"url":"/v3/kafka/local/consumer","host":"48fa52eee460"}}% 
```

add a consumer group:
```
╰─○ kafkacat -Cb localhost:9092 -G diego test-topic
% Waiting for group rebalance
% Group diego rebalanced (memberid rdkafka-ca2754f1-25f5-481e-b6c0-defd28513caf): assigned: test-topic [0], test-topic
```

check after some seconds burrow:
```
╰─○ curl localhost:8000/v3/kafka/local/consumer
{"error":false,"message":"consumer list returned","consumers":["diego","burrow-local"],"request":{"url":"/v3/kafka/local/consumer","host":"48fa52eee460"}}%                                                                                   
╭─[16:04:52] diegoalvarez@d1egoaz-MBP/ ~/src/github.com/Shopify/burrow

╰─○ curl localhost:8000/v3/kafka/local/consumer/diego
{"error":false,"message":"consumer detail returned","topics":{"test-topic":[{"offsets":[null,null,null,null,null,null,null,{"offset":4,"timestamp":1599865466521,"lag":0},{"offset":5,"timestamp":1599865486526,"lag":0},{"offset":9,"timestamp":1599865491523,"lag":0}],"owner":"","client_id":"","current-lag":0},{"offsets":[null,null,null,null,null,null,null,null,null,{"offset":5,"timestamp":1599865466521,"lag":0}],"owner":"","client_id":"","current-lag":0}]},"request":{"url":"/v3/kafka/local/consumer/diego","host":"48fa52eee460"}}% 

```

stop consumer and delete consumer group or wait until the consumer offsets retention expires:
```
╰─○ kafka-consumer-groups --delete --group diego --bootstrap-server localhost:9092
Deletion of requested consumer groups ('diego') was successful.
```

kafka reports the deleted consumer group
```
kafka_1      | [2020-09-11 23:05:38,101] INFO [GroupCoordinator 1001]: The following groups were deleted: diego. A total of 2 offsets were removed. (kafka.coordinator.group.GroupCoordinator)
```

then the groups reaper deletes this consumer:
```
burrow_1     | {"level":"info","ts":1599865553.5991886,"msg":"groups reaper: removing non existing kafka consumer group (diego) from burrow","type":"module","coordinator":"cluster","class":"kafka","name":"local"}
```


burrow stops reporting lag as the group is removed:
```
╰─○ curl localhost:8000/v3/kafka/local/consumer/diego
{"error":true,"message":"cluster or consumer not found","request":{"url":"/v3/kafka/local/consumer/diego","host":"48fa52eee460"}}%                                                                                                            
╭─[16:05:55] diegoalvarez@d1egoaz-MBP/ ~/src/github.com/Shopify/burrow

╰─○ curl localhost:8000/v3/kafka/local/consumer
{"error":false,"message":"consumer list returned","consumers":["burrow-local"],"request":{"url":"/v3/kafka/local/consumer","host":"48fa52eee460"}}% 
```

it also fixes:
https://github.com/linkedin/Burrow/issues/589
