### PR TITLE
Cache dependencies in docker build using go mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,14 @@ FROM golang:1.15.2-alpine as builder
 ENV BURROW_SRC /usr/src/Burrow/
 
 RUN apk add --no-cache git curl
-COPY . $BURROW_SRC
 WORKDIR $BURROW_SRC
 
-RUN go mod tidy && go build -o /tmp/burrow .
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . $BURROW_SRC
+RUN go build -o /tmp/burrow .
 
 # stage 2: runner
 FROM alpine:3.12


### PR DESCRIPTION
After making a source change to Burrow, the docker build downloads the entire set of dependencies each time the image is built.

By downloading dependencies before building Burrow itself, we leverage docker's build cache to skip downloading all of the dependencies in subsequent rebuilds.