### PR TITLE
Fix reporting final offset in backfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
 
@@ -26,13 +26,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-
-    # See https://github.com/actions/setup-go/issues/14
-    - name: Setup env
-      run: |
-        echo "::set-env name=GOPATH::$(go env GOPATH)"
-        echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
 
     - name: Install dependencies
       run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0

--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -255,6 +255,9 @@ func (module *KafkaClient) partitionConsumer(consumer sarama.PartitionConsumer, 
 				}
 				helpers.TimeoutSendStorageRequest(module.App.StorageChannel, burrowOffset, 1)
 			}
+
+			module.processConsumerOffsetsMessage(msg)
+
 			if stopAtOffset != nil && msg.Offset >= stopAtOffset.Value {
 				module.Log.Debug("backfill consumer reached target offset, terminating",
 					zap.Int32("partition", msg.Partition),
@@ -262,7 +265,6 @@ func (module *KafkaClient) partitionConsumer(consumer sarama.PartitionConsumer, 
 				)
 				return
 			}
-			module.processConsumerOffsetsMessage(msg)
 		case err := <-consumer.Errors():
 			module.Log.Error("consume error",
 				zap.String("topic", err.Topic),


### PR DESCRIPTION
Much related to #616 but for the actual `__consumer_offsets` message!

Currently, all backfilled partitions are skipping the final message.

This is not an issue if the consumer group is busy and committing often,
however, if that is not the case it can lead to `Burrow` reporting
(a single consumer group topic partition) as being with status `STOP`
erroneously. This behaviour persists across restarts if no new messages
have been produced on the given `__consumer_offsets` partition.

\cc @bai & @timbertson :smile: