### PR TITLE
Adding Readiness Endpoint

### DIFF
--- a/core/internal/consumer/coordinator.go
+++ b/core/internal/consumer/coordinator.go
@@ -106,6 +106,9 @@ func (cc *Coordinator) Start() error {
 	if err != nil {
 		return errors.New("Error starting consumer module: " + err.Error())
 	}
+	// All consumers started, Burrow is ready to serve requests
+	// set the readiness probe
+	cc.App.AppReady = true
 	return nil
 }
 

--- a/core/internal/httpserver/coordinator.go
+++ b/core/internal/httpserver/coordinator.go
@@ -126,8 +126,9 @@ func (hc *Coordinator) Configure() {
 	// This is a catchall for undefined URLs
 	hc.router.NotFound = &defaultHandler{}
 
-	// This is a healthcheck URL. Please don't change it
+	// This is a healthcheck and readiness URLs. Please don't change it
 	hc.router.GET("/burrow/admin", hc.handleAdmin)
+	hc.router.GET("/burrow/admin/ready", hc.handleReady)
 
 	hc.router.Handler(http.MethodGet, "/metrics", hc.handlePrometheusMetrics())
 
@@ -294,6 +295,24 @@ func (hc *Coordinator) handleAdmin(w http.ResponseWriter, r *http.Request, _ htt
 
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("GOOD"))
+}
+
+// handleReady will use the AppReady bool from  the ApplicationContext to determine
+// whether Burrow is ready to serve requests
+func (hc *Coordinator) handleReady(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	// Add CORS header, if configured
+	corsHeader := viper.GetString("general.access-control-allow-origin")
+	if corsHeader != "" {
+		w.Header().Set("Access-Control-Allow-Origin", corsHeader)
+	}
+
+	if hc.App.AppReady {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("READY"))
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("STARTING"))
+	}
 }
 
 func (hc *Coordinator) getLogLevel(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -60,6 +60,9 @@ type ApplicationContext struct {
 	// This is the channel over which any module should send storage requests for storage of offsets and group
 	// information, or to fetch the same information. It is serviced by the storage Coordinator.
 	StorageChannel chan *StorageRequest
+
+	// This is a boolean flag which is set by the last subsystem, the consumer, in order to signal when Burrow is ready
+	AppReady bool
 }
 
 // Module is a common interface for all modules so that they can be manipulated by the coordinators in the same way.


### PR DESCRIPTION
Hi :smile: 
I'm creating this PR after facing related issues in our environment.
I think that it's a good idea to add a [Readiness endpoint](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) to Burrow.

On Burrow startup, it configures and starts the coordinators one by one in a predefined order (ZK, Storage, Evaluator, HTTP, and so on).
It makes a lot of sense, but the `healthcheck` itself is initialized on the HTTP subsystem and returns `HTTP 200` no matter what's the **real** status of Burrow is, like mention on the [Wiki page](https://github.com/linkedin/Burrow/wiki/http-request-healthcheck).

This causes an issue when something is not right with one of the Kafka / Zookeeper clusters and the **consumer subsystem fails** -
our orchestration system already got the `HTTP 200` (which initialized before even connecting to any client) and marked the deployment of Burrow as a success, and causing **silent failure**.

In order to avoid this situation, I added a readiness probe, that will be switched only after the last subsystem (the consumer) finish to be initialized with a success, to mark that Burrow is ready to serve requests.

- [x] Add the feature
- [x] Cover with test for both startup state and ready state
- [ ] Document in the Wiki page

Thank you!