### PR TITLE
Update base alpine image from 3.12 to 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR $BURROW_SRC
 RUN go mod tidy && go build -o /tmp/burrow .
 
 # stage 2: runner
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL maintainer="LinkedIn Burrow https://github.com/linkedin/Burrow"
 

--- a/Dockerfile.gorelease
+++ b/Dockerfile.gorelease
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 LABEL maintainer="LinkedIn Burrow https://github.com/linkedin/Burrow"
 
 WORKDIR /app


### PR DESCRIPTION
Bump base Alpine Linux version for both builder and runner (release) docker images.