### PR TITLE
fix NPE for err & msg in kafka_client.go

### DIFF
--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -242,6 +242,9 @@ func (module *KafkaClient) partitionConsumer(consumer sarama.PartitionConsumer, 
 	for {
 		select {
 		case msg := <-consumer.Messages():
+			if msg == nil {
+				continue
+			}
 			if module.reportedConsumerGroup != "" {
 				burrowOffset := &protocol.StorageRequest{
 					RequestType: protocol.StorageSetConsumerOffset,
@@ -266,6 +269,9 @@ func (module *KafkaClient) partitionConsumer(consumer sarama.PartitionConsumer, 
 				return
 			}
 		case err := <-consumer.Errors():
+			if err == nil {
+				continue
+			}
 			module.Log.Error("consume error",
 				zap.String("topic", err.Topic),
 				zap.Int32("partition", err.Partition),


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa32efb]

goroutine 269 [running]:
github.com/linkedin/Burrow/core/internal/consumer.(*KafkaClient).partitionConsumer(0xc000768fa0, 0xead338, 0xc00013d360, 0x0)
        ~/go/src/github.com/linkedin/Burrow/core/internal/consumer/kafka_client.go:270 +0x57b
created by github.com/linkedin/Burrow/core/internal/consumer.(*KafkaClient).startKafkaConsumer
        ~/go/src/github.com/linkedin/Burrow/core/internal/consumer/kafka_client.go:322 +0x8d6

maybe related issue: #634 #353 ?