### PR TITLE
Fix to show metrics for incomplete partitions

### DIFF
--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -76,7 +76,7 @@ func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 				consumerStatusGauge.With(labels).Set(float64(consumerStatus.Status))
 
 				for _, partition := range consumerStatus.Partitions {
-          labels := map[string]string{
+					labels := map[string]string{
 						"cluster":        cluster,
 						"consumer_group": consumer,
 						"topic":          partition.Topic,

--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -63,8 +63,7 @@ func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 				consumerStatus := getFullConsumerStatus(hc.App, cluster, consumer)
 
 				if consumerStatus == nil ||
-					consumerStatus.Status == protocol.StatusNotFound ||
-					consumerStatus.Complete < 1.0 {
+					consumerStatus.Status == protocol.StatusNotFound {
 					continue
 				}
 
@@ -77,10 +76,7 @@ func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 				consumerStatusGauge.With(labels).Set(float64(consumerStatus.Status))
 
 				for _, partition := range consumerStatus.Partitions {
-					if partition.Complete < 1.0 {
-						continue
-					}
-
+				
 					labels := map[string]string{
 						"cluster":        cluster,
 						"consumer_group": consumer,
@@ -88,8 +84,11 @@ func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 						"partition":      strconv.FormatInt(int64(partition.Partition), 10),
 					}
 
-					consumerPartitionCurrentOffset.With(labels).Set(float64(partition.End.Offset))
 					consumerPartitionLagGauge.With(labels).Set(float64(partition.CurrentLag))
+
+					if partition.Complete == 1.0 {
+						consumerPartitionCurrentOffset.With(labels).Set(float64(partition.End.Offset))
+					}
 				}
 			}
 

--- a/core/internal/httpserver/prometheus_test.go
+++ b/core/internal/httpserver/prometheus_test.go
@@ -151,6 +151,6 @@ func TestHttpServer_handlePrometheusMetrics(t *testing.T) {
 	assert.Contains(t, promExp, `burrow_kafka_topic_partition_offset{cluster="testcluster",partition="1",topic="testtopic"} 5566`)
 	assert.Contains(t, promExp, `burrow_kafka_topic_partition_offset{cluster="testcluster",partition="0",topic="testtopic1"} 54`)
 
-	assert.NotContains(t, promExp, `burrow_kafka_consumer_partition_lag{cluster="testcluster",consumer_group="testgroup",partition="0",topic="incomplete"} 0`)
+	assert.Contains(t, promExp, `burrow_kafka_consumer_partition_lag{cluster="testcluster",consumer_group="testgroup",partition="0",topic="incomplete"} 0`)
 	assert.NotContains(t, promExp, "testgroup2")
 }


### PR DESCRIPTION
There was a [PR open for some time](https://github.com/linkedin/Burrow/pull/638) with outstanding comments. Have addressed the comments from the original PR for the issue #637

We have been using a forked version of burrow for some time on our projects as we have issues in test environments where there are topics with no activity.