### PR TITLE
Fix parseInt error when offset is null

### DIFF
--- a/core/internal/consumer/kafka_zk_client.go
+++ b/core/internal/consumer/kafka_zk_client.go
@@ -443,7 +443,15 @@ func (module *KafkaZkClient) resetOffsetWatchAndSend(group, topic string, partit
 	}
 	module.running.Add(1)
 	go module.watchOffset(group, topic, partition, offsetEventChan)
-
+	if string(offsetString) == "" {
+		module.Log.Error("badly formatted offset null",
+			zap.String("group", group),
+			zap.String("topic", topic),
+			zap.Int32("partition", partition),
+			zap.String("error", err.Error()),
+		)
+		return
+	}
 	if !resetOnly {
 		offset, err := strconv.ParseInt(string(offsetString), 10, 64)
 		if err != nil {


### PR DESCRIPTION
- kafka version: 2.3.0
- burrow version: v1.3.6
- issue: i found some error when i use burrow, like this

{"level":"error","ts":1622719692.6220706,"msg":"badly formatted offset","type":"module","coordinator":"consumer","class":"kafka_zk","name":"kafka23-1-kafka_zk","group":"rover_trace_259_test","topic":"S-rover","partition":5,"offset_string":"","error":"strconv.ParseInt: parsing \"\": invalid syntax"}

- because the offset metadata in zookeeper is a empty string. so i need to pass it。

