### PR TITLE
Revert "fix prometheus metrics leakage when nonexisting consumer removed from memory"

### DIFF
--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -12,7 +12,6 @@ package cluster
 
 import (
 	"fmt"
-	"github.com/linkedin/Burrow/core/internal/httpserver"
 	"sync"
 	"time"
 
@@ -329,15 +328,6 @@ func (module *KafkaCluster) reapNonExistingGroups(client helpers.SaramaClient) {
 			continue
 		}
 		if _, ok := kafkaGroups[g]; !ok {
-			request0 := &protocol.EvaluatorRequest{
-				Cluster: module.name,
-				Group:   g,
-				ShowAll: true,
-				Reply:   make(chan *protocol.ConsumerGroupStatus),
-			}
-			module.App.EvaluatorChannel <- request0
-			response := <-request0.Reply
-			httpserver.DeleteMetrics(module.name, g, response)
 			module.Log.Info(fmt.Sprintf("groups reaper: removing non existing kafka consumer group (%s) from burrow", g))
 			request := &protocol.StorageRequest{
 				RequestType: protocol.StorageSetDeleteGroup,

--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -54,31 +54,6 @@ var (
 	)
 )
 
-func DeleteMetrics(cluster string, consumer string, consumerStatus *protocol.ConsumerGroupStatus) {
-
-	if consumerStatus == nil ||
-		consumerStatus.Status == protocol.StatusNotFound {
-		return
-	}
-	labels := map[string]string{
-		"cluster":        cluster,
-		"consumer_group": consumer,
-	}
-	consumerTotalLagGauge.Delete(labels)
-	consumerStatusGauge.Delete(labels)
-
-	for _, partition := range consumerStatus.Partitions {
-		labels := map[string]string{
-			"cluster":        cluster,
-			"consumer_group": consumer,
-			"topic":          partition.Topic,
-			"partition":      strconv.FormatInt(int64(partition.Partition), 10),
-		}
-		consumerPartitionLagGauge.Delete(labels)
-		consumerPartitionCurrentOffset.Delete(labels)
-	}
-}
-
 func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 	promHandler := promhttp.Handler()
 


### PR DESCRIPTION
Reverts linkedin/Burrow#708