### PR TITLE
Fix deprecated binaries goreleaser field

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,6 @@ dockers:
 - goos: linux
   goarch: amd64
   goarm: ''
-  binaries:
-  - burrow
   dockerfile: Dockerfile.gorelease
   image_templates:
   - 'docker.pkg.github.com/linkedin/burrow/burrow:latest'


### PR DESCRIPTION
Fix `line 33: field binaries not found in type config.Docker` goreleaser error.