### PR TITLE
Tweak build flags for internalDup2 on darwin arm64

### DIFF
--- a/core/open_out_log_unix.go
+++ b/core/open_out_log_unix.go
@@ -1,5 +1,6 @@
-//go:build !windows && !arm64
-// +build !windows,!arm64
+//go:build !windows && !(linux && arm64)
+// +build !windows
+// +build !linux !arm64
 
 /* Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
  * 2.0 (the "License"); you may not use this file except in compliance with


### PR DESCRIPTION
Fixes an issue that prevents building on darwin amr64 (M1 macs):
```
$ go build .
# github.com/linkedin/Burrow/core
core/logger.go:172:2: undefined: internalDup2
core/logger.go:173:2: undefined: internalDup2
```

My understanding is that `open_out_log_unix.go` was designed to be used everywhere _except_ `windows` and `linux_arm64`, as evidenced by the comment:
> linux_arm64 doesn't have syscall.Dup2, so use the nearly identical syscall.Dup3 instead

However, the build flags in `open_out_log_unix.go` were also excluding `darwin_arm64`, which was not provided (rightly so) by `open_out_log_linux_arm64.go`.

I decided to go the route of making the build flags of `open_out_log_unix.go` only exclude `linux_arm64` instead of adding mentions of darwin, because I felt it was more semantic; a better representation of the inherent non-overlapping union of the 3 flags:
1. `windows`
2. `linux_arm64`
3. `!windows && !linux_arm64` (not the first 2)