### PR TITLE
Sasl plain

### DIFF
--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -129,6 +129,9 @@ func GetSaramaConfigFromClientProfile(profileName string) *sarama.Config {
 			saramaConfig.Net.SASL.SCRAMClientGeneratorFunc = func() sarama.SCRAMClient {
 				return &XDGSCRAMClient{HashGeneratorFcn: SHA512}
 			}
+		} else if mechanism == "PLAIN" {
+			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
+			viper.Set("sasl." + saslName + ".handshake-first", true)
 		}
 		saramaConfig.Net.SASL.Handshake = viper.GetBool("sasl." + saslName + ".handshake-first")
 		saramaConfig.Net.SASL.User = viper.GetString("sasl." + saslName + ".username")

--- a/core/internal/helpers/sarama.go
+++ b/core/internal/helpers/sarama.go
@@ -131,7 +131,7 @@ func GetSaramaConfigFromClientProfile(profileName string) *sarama.Config {
 			}
 		} else if mechanism == "PLAIN" {
 			saramaConfig.Net.SASL.Mechanism = sarama.SASLTypePlaintext
-			viper.Set("sasl." + saslName + ".handshake-first", true)
+			viper.Set("sasl."+saslName+".handshake-first", true)
 		}
 		saramaConfig.Net.SASL.Handshake = viper.GetBool("sasl." + saslName + ".handshake-first")
 		saramaConfig.Net.SASL.User = viper.GetString("sasl." + saslName + ".username")


### PR DESCRIPTION
- sarama library supports SASL/PLAIN authentication mechanism
- this patch to support SASL/PLAIN
- but, handshake-first must be true
- tested kafka 2.6.0 and after