### PR TITLE
Add riscv64 support

### DIFF
--- a/core/open_out_log_linux_dup3.go
+++ b/core/open_out_log_linux_dup3.go
@@ -1,5 +1,6 @@
-//go:build linux && arm64
+//go:build linux && (arm64 || riscv64)
 // +build linux,arm64
+// +build linux,riscv64
 
 // Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
 // 2.0 (the "License"); you may not use this file except in compliance with
@@ -16,7 +17,7 @@ import (
 	"syscall"
 )
 
-// linux_arm64 doesn't have syscall.Dup2, so use
+// linux_arm64 and linux_riscv64 doesn't have syscall.Dup2, so use
 // the nearly identical syscall.Dup3 instead
 func internalDup2(oldfd uintptr, newfd uintptr) error {
 	return syscall.Dup3(int(oldfd), int(newfd), 0)


### PR DESCRIPTION
Modified build flags so that it will compile on riscv64.

Other platforms may not support `dup2` as well, so please let me know if there are some, and I will add them too.

This patch is built upon https://github.com/linkedin/Burrow/pull/743. Please merge that before merging my PR.