### PR TITLE
Fix metric leak

### DIFF
--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/linkedin/Burrow/core/internal/helpers"
+	"github.com/linkedin/Burrow/core/internal/httpserver"
 	"github.com/linkedin/Burrow/core/protocol"
 )
 
@@ -334,6 +335,8 @@ func (module *KafkaCluster) reapNonExistingGroups(client helpers.SaramaClient) {
 				Group:       g,
 			}
 			helpers.TimeoutSendStorageRequest(module.App.StorageChannel, request, 1)
+
+			httpserver.DeleteConsumerMetrics(module.name, g)
 		}
 	}
 }

--- a/core/internal/cluster/kafka_cluster.go
+++ b/core/internal/cluster/kafka_cluster.go
@@ -199,6 +199,7 @@ func (module *KafkaCluster) maybeUpdateMetadataAndDeleteTopics(client helpers.Sa
 						Cluster:     module.name,
 						Topic:       topic,
 					}
+					httpserver.DeleteTopicMetrics(module.name, topic)
 				}
 			}
 		}

--- a/core/internal/consumer/kafka_client.go
+++ b/core/internal/consumer/kafka_client.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/linkedin/Burrow/core/internal/helpers"
+	"github.com/linkedin/Burrow/core/internal/httpserver"
 	"github.com/linkedin/Burrow/core/protocol"
 )
 
@@ -521,6 +522,8 @@ func (module *KafkaClient) decodeGroupMetadata(keyBuffer *bytes.Buffer, value []
 			Group:       group,
 		}
 		helpers.TimeoutSendStorageRequest(module.App.StorageChannel, deleteMessage, 1)
+
+		httpserver.DeleteConsumerMetrics(module.name, group)
 		return
 	}
 

--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -54,6 +54,19 @@ var (
 	)
 )
 
+// DeleteConsumerMetrics deletes all metrics that are labeled with a consumer group
+func DeleteConsumerMetrics(cluster, consumer string) {
+	labels := map[string]string{
+		"cluster":        cluster,
+		"consumer_group": consumer,
+	}
+
+	consumerTotalLagGauge.Delete(labels)
+	consumerStatusGauge.Delete(labels)
+	consumerPartitionLagGauge.DeletePartialMatch(labels)
+	consumerPartitionCurrentOffset.DeletePartialMatch(labels)
+}
+
 func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 	promHandler := promhttp.Handler()
 

--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -67,6 +67,23 @@ func DeleteConsumerMetrics(cluster, consumer string) {
 	consumerPartitionCurrentOffset.DeletePartialMatch(labels)
 }
 
+// DeleteTopicMetrics deletes all metrics that are labeled with a topic
+func DeleteTopicMetrics(cluster, topic string) {
+	labels := map[string]string{
+		"cluster": cluster,
+		"topic":   topic,
+	}
+
+	topicPartitionOffsetGauge.DeletePartialMatch(labels)
+
+	// If a topic is deleted there cannot be any consumers, so delete all consumer metrics too
+	// Not strictly necessary as Kafka will delete the consumer groups, which will eventually trigger DeleteConsumerMetrics
+	consumerPartitionLagGauge.DeletePartialMatch(labels)
+	consumerPartitionCurrentOffset.DeletePartialMatch(labels)
+	consumerTotalLagGauge.DeletePartialMatch(labels)
+	consumerStatusGauge.DeletePartialMatch(labels)
+}
+
 func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 	promHandler := promhttp.Handler()
 


### PR DESCRIPTION
When running Burrow on busy clusters we noticed our scrape times would slowly increase, until they hit the scrape timeout. This was caused by metrics never being expired when a consumer group or topic is modified. This PR aims to fix this with the following changes:

1. Delete metrics when consumer groups are removed: The DeleteConsumerMetrics method is called in two places, either when a tombstone is processed in the __consumer_offsets topic, or when the group reaper detects a consumer group that no longer exists. It is necessary in both places as not all offsets are managed using the __consumer_offsets topic.

2. Delete metrics when a topic is removed: All metrics relating to the topic are removed, including consumer group metrics, as the consumer groups will no longer exist for the topic to have been deleted.