### PR TITLE
Add DeleteConsumerMetrics for every delete consumer.

### DIFF
--- a/core/internal/storage/inmemory.go
+++ b/core/internal/storage/inmemory.go
@@ -11,6 +11,7 @@ package storage
 
 import (
 	"container/ring"
+	"github.com/linkedin/Burrow/core/internal/httpserver"
 	"math/rand"
 	"regexp"
 	"sync"
@@ -668,6 +669,7 @@ func (module *InMemoryStorage) deleteGroup(request *protocol.StorageRequest, req
 	clusterMap.consumerLock.Lock()
 	delete(clusterMap.consumer, request.Group)
 	clusterMap.consumerLock.Unlock()
+	httpserver.DeleteConsumerMetrics(request.Cluster, request.Group)
 
 	requestLogger.Debug("ok")
 }


### PR DESCRIPTION
English is not my native language; please excuse typing errors.

When I use the API(/v3/kafka/:cluster/consumer/:consumer) to delete consumers or this consumer has expired, I can still get metrics for which is deleted  in the metrics.
I think it should disappear from metrics.