### PR TITLE
Add partition status metric

### DIFF
--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -29,6 +29,14 @@ var (
 		[]string{"cluster", "consumer_group"},
 	)
 
+	partitionStatusGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "burrow_kafka_topic_partition_status",
+			Help: "The status of topic partition. It is calculated from the highest status for the individual partitions. Statuses are an index list from OK, WARN, STOP, STALL, REWIND",
+		},
+		[]string{"cluster", "consumer_group", "topic", "partition"},
+	)
+
 	consumerPartitionCurrentOffset = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "burrow_kafka_consumer_current_offset",
@@ -117,6 +125,7 @@ func (hc *Coordinator) handlePrometheusMetrics() http.HandlerFunc {
 
 					if partition.Complete == 1.0 {
 						consumerPartitionCurrentOffset.With(labels).Set(float64(partition.End.Offset))
+						partitionStatusGauge.With(labels).Set(float64(partition.Status))
 					}
 				}
 			}

--- a/core/internal/httpserver/prometheus.go
+++ b/core/internal/httpserver/prometheus.go
@@ -24,7 +24,7 @@ var (
 	consumerStatusGauge = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "burrow_kafka_consumer_status",
-			Help: "The status of the consumer group. It is calculated from the highest status for the individual partitions. Statuses are an index list from NOTFOUND, OK, WARN, ERR, STOP, STALL, REWIND",
+			Help: "The status of the consumer group. It is calculated from the highest status for the individual partitions. Statuses are an index list from NOTFOUND, OK, WARN, or ERR",
 		},
 		[]string{"cluster", "consumer_group"},
 	)


### PR DESCRIPTION
Following the PR ([628](https://github.com/linkedin/Burrow/pull/628/files#diff-76b9dbd33c4ba3f0af8c0298cd11ce84f307d786615afaf66a53466c71b9ff03)) and the issue ([318](https://github.com/linkedin/Burrow/issues/318)).

There are two things in this PR:
1. Adding burrow metric for exposing the partition status of [this](https://github.com/linkedin/Burrow/wiki/http-request-consumer-group-status). Until now, only the consumer group status is exported. 
2. Fixing description for "burrow_kafka_consumer_status" metric. It only can be  NOTFOUND, OK, WARN, or ERR states based on [StatusConstant](https://github.com/linkedin/Burrow/blob/master/core/protocol/evaluator.go#L106)