### PR TITLE
Build on loong64

### DIFF
--- a/core/open_out_log_linux_loong64.go
+++ b/core/open_out_log_linux_loong64.go
@@ -1,7 +1,5 @@
-//go:build !windows && !(linux && arm64) && !(linux && loong64)
-// +build !windows
-// +build !linux !arm64
-// +build !linux !loong64
+//go:build linux && loong64
+// +build linux,loong64
 
 // Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
 // 2.0 (the "License"); you may not use this file except in compliance with
@@ -18,6 +16,8 @@ import (
 	"syscall"
 )
 
-func internalDup2(oldfd, newfd uintptr) error {
-	return syscall.Dup2(int(oldfd), int(newfd))
+// linux_loong64 doesn't have syscall.Dup2, so use
+// the nearly identical syscall.Dup3 instead
+func internalDup2(oldfd uintptr, newfd uintptr) error {
+	return syscall.Dup3(int(oldfd), int(newfd), 0)
 }


### PR DESCRIPTION
The package burrow failed to compile on loong64 in the Debian Package Auto-Building environment. 
The error messages is as follows,
```
# github.com/linkedin/Burrow/core
src/github.com/linkedin/Burrow/core/open_out_log_unix.go:21:17: undefined: syscall.Dup2
```
The full compilation log can be found at https://buildd.debian.org/status/logs.php?pkg=burrow&ver=1.2.1-2&arch=loong64

Applying this commit, I'm compiling fine in my local Debian rootfs environment.
```
root@localhost:/home/burrow# ls
burrow-1.2.1			   burrow_1.2.1-2.debian.tar.xz  burrow_1.2.1-2_loong64.buildinfo  burrow_1.2.1-2_loong64.deb
burrow-dbgsym_1.2.1-2_loong64.deb  burrow_1.2.1-2.dsc		 burrow_1.2.1-2_loong64.changes    burrow_1.2.1.orig.tar.gz
root@localhost:/home/burrow# go version
go version go1.21.1 linux/loong64
```
Please review.