### PR TITLE
core: Support Unix domain socket HTTP server listener

### DIFF
--- a/core/internal/helpers/validation.go
+++ b/core/internal/helpers/validation.go
@@ -112,6 +112,10 @@ func ValidateHostList(hosts []string) bool {
 // ValidateHostPort returns true if the provided string is of the form "hostname:port", where hostname is a valid
 // hostname or IP address (as parsed by ValidateIP or ValidateHostname), and port is a valid integer.
 func ValidateHostPort(host string, allowBlankHost bool) bool {
+	if strings.HasPrefix(host, "unix:") {
+		return true
+	}
+
 	// Must be hostname:port, ipv4:port, or [ipv6]:port. Optionally allow blank hostname
 	hostname, portString, err := net.SplitHostPort(host)
 	if err != nil {


### PR DESCRIPTION
This PR implements support for listening on a Unix domain socket for Burrow's main HTTP server. Users can specify an address of the form `unix:/path/to/socket` to enable the Unix socket listener, instead of the traditional TCP-based listener.

## Test Plan

Example config:

```toml
[logging]
level="info"
use-localtime=false

[zookeeper]
servers=["localhost:2181"]
timeout=6
root-path="/burrow"

[client-profile.local]
client-id="burrow"
kafka-version="1.0.0"

[cluster.local]
class-name="kafka"
servers=["localhost:9092"]
client-profile="local"
topic-refresh=120
offset-refresh=10

[consumer.local]
class-name="kafka"
cluster="local"
servers=["localhost:9092"]
client-profile="local"
group-denylist="^(console-consumer-|python-kafka-consumer-|quick-).*$"
group-allowlist=""

[httpserver.default]
address="unix:/tmp/burrow.sock"
```

Usage:

```bash
$ ./bin/burrow --config-dir /tmp/burrow
Reading configuration from /tmp/burrow
{"level":"info","ts":1706928222.3937771,"msg":"Started Burrow"}
```

Verification:

```bash
$ curl --unix-socket /tmp/burrow.sock http://localhost/v3/kafka/local/topic
{"error":false,"message":"topic list returned","topics":[...],"request":{"url":"/v3/kafka/local/topic","host":"..."}}
```