### PR TITLE
Update Go to 1.21.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1: builder
-FROM golang:1.21.1-alpine as builder
+FROM golang:1.21.8-alpine as builder
 
 ENV BURROW_SRC /usr/src/Burrow/
 


### PR DESCRIPTION
Update to go 1.21.8 to remove matches for CVE-2023-44487