### PR TITLE
Add ARM64 platform artifacts to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,9 @@ dockers:
   goarch: amd64
   dockerfile: Dockerfile.gorelease
   image_templates:
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:latest'
   - 'docker.pkg.github.com/linkedin/burrow/burrow:latest-amd64'
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}'
   - 'docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-amd64'
   extra_files:
   - docker-config/burrow.toml
@@ -64,5 +66,6 @@ dockers:
 docker_manifests:
 - name_template: "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}"
   image_templates:
+  - "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}"
   - "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-amd64"
   - "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 project_name: Burrow
+version: 2
 
 builds:
 - main: main.go
@@ -11,8 +12,12 @@ builds:
   - linux
   goarch:
   - amd64
+  - arm64
 archives:
-- format: tar.gz
+- formats: [tar.gz]
+  format_overrides:
+  - goos: windows
+    formats: [zip]
   files:
   - LICENSE
   - NOTICE
@@ -25,15 +30,14 @@ archives:
   - config/default-slack-delete.tmpl
   - config/default-slack-post.tmpl
 snapshot:
-  name_template: "{{ .FullCommit }}"
+  version_template: "{{ .FullCommit }}"
 dockers:
 - goos: linux
   goarch: amd64
-  goarm: ''
   dockerfile: Dockerfile.gorelease
   image_templates:
-  - 'docker.pkg.github.com/linkedin/burrow/burrow:latest'
-  - 'docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}'
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:latest-amd64'
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-amd64'
   extra_files:
   - docker-config/burrow.toml
   build_flag_templates:
@@ -42,3 +46,23 @@ dockers:
   - "--label=org.label-schema.name={{ .ProjectName }}"
   - "--label=org.label-schema.vcs=https://github.com/linkedin/Burrow"
   - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"
+
+- goos: linux
+  goarch: arm64
+  dockerfile: Dockerfile.gorelease
+  image_templates:
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:latest-arm64'
+  - 'docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-arm64'
+  extra_files:
+  - docker-config/burrow.toml
+  build_flag_templates:
+  - "--label=org.label-schema.schema-version=1.0"
+  - "--label=org.label-schema.version={{ .Version }}"
+  - "--label=org.label-schema.name={{ .ProjectName }}"
+  - "--label=org.label-schema.vcs=https://github.com/linkedin/Burrow"
+  - "--label=org.label-schema.vcs-ref={{ .FullCommit }}"
+docker_manifests:
+- name_template: "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}"
+  image_templates:
+  - "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-amd64"
+  - "docker.pkg.github.com/linkedin/burrow/burrow:{{ .Tag }}-arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,7 +17,7 @@ archives:
 - formats: [tar.gz]
   format_overrides:
   - goos: windows
-    formats: [zip]
+    formats: [zip,tar.gz]
   files:
   - LICENSE
   - NOTICE


### PR DESCRIPTION
Proposed changes add ARM64 artifacts to the release assets.
Few minor deprecations in the **.goreleaser.yaml** have been fixed alongside.