### PR TITLE
Add platform support for darwin,arm64 / Apple Silicon

### DIFF
--- a/core/open_out_log_darwin_arm64.go
+++ b/core/open_out_log_darwin_arm64.go
@@ -1,0 +1,22 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+/* Copyright 2017 LinkedIn Corp. Licensed under the Apache License, Version
+ * 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package core
+
+import (
+	"syscall"
+)
+
+func internalDup2(oldfd uintptr, newfd uintptr) error {
+	return syscall.Dup2(int(oldfd), int(newfd))
+}

--- a/go.mod
+++ b/go.mod
@@ -1,29 +1,58 @@
 module github.com/linkedin/Burrow
 
+go 1.24.5
+
 require (
-	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/OneOfOne/xxhash v1.2.2
 	github.com/Shopify/sarama v1.23.1
-	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/google/uuid v1.1.0 // indirect
-	github.com/jcmturner/gofork v1.0.0 // indirect
 	github.com/julienschmidt/httprouter v0.0.0-20181021223831-26a05976f9bf
 	github.com/karrick/goswarm v1.9.1
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec
-	github.com/spf13/afero v1.2.0 // indirect
 	github.com/spf13/viper v1.3.1
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
+	go.uber.org/zap v1.9.1
+	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
+)
+
+require (
+	github.com/BurntSushi/toml v0.3.1 // indirect
+	github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798 // indirect
+	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/eapache/go-resiliency v1.1.0 // indirect
+	github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21 // indirect
+	github.com/eapache/queue v1.1.0 // indirect
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/google/uuid v1.1.0 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/jcmturner/gofork v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.2.0 // indirect
+	github.com/pierrec/lz4 v0.0.0-20190327172049-315a67e90e41 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a // indirect
+	github.com/spf13/afero v1.2.0 // indirect
+	github.com/spf13/cast v1.3.0 // indirect
+	github.com/spf13/jwalterweatherman v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/stretchr/objx v0.1.1 // indirect
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
-	go.uber.org/zap v1.9.1
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6 // indirect
+	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect
+	golang.org/x/text v0.3.0 // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
-	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
+	gopkg.in/jcmturner/aescts.v1 v1.0.1 // indirect
+	gopkg.in/jcmturner/dnsutils.v1 v1.0.1 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.0.0-20170531160350-a96e63847dc3
+	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -59,7 +59,6 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a h1:9ZKAASQSHhD
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec h1:6ncX5ko6B9LntYM0YBRXkiSaZMmLYeZ/NWcmeB43mMY=
 github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.0 h1:O9FblXGxoTc51M+cqr74Bm2Tmt4PvkA5iu/j8HrkNuY=


### PR DESCRIPTION
## Fix compilation error on macOS ARM64 (Apple Silicon)

### Issue
Burrow fails to compile on macOS ARM64 systems with the following error:

```
16:06:05 ❯ go install
# github.com/linkedin/Burrow/core
core/logger.go:174:2: undefined: internalDup2
core/logger.go:175:2: undefined: internalDup2
```

The existing platform-specific implementations of `internalDup2()` don't cover macOS ARM64:

- `open_out_log_unix.go`: Excludes ARM64 entirely (`!windows` AND `!arm64`)
- `open_out_log_linux_arm64.go`: Only targets Linux ARM64 (`linux,arm64`) 
- `open_out_log_windows.go`: Windows only (`windows`)

This leaves macOS ARM64 without any implementation of the required `internalDup2` function.

### Solution
Added `core/open_out_log_darwin_arm64.go` with build constraint `// +build darwin,arm64` that implements `internalDup2()` using `syscall.Dup2()` - the same implementation as other Unix-based systems.

### Changes
- **Added**: `core/open_out_log_darwin_arm64.go` - macOS ARM64 specific implementation
- **Updatd**: Dependencies via `go mod tidy`
- **Behavior**: Identical to existing Unix implementation (uses `syscall.Dup2`)
- **Scope**: Only affects macOS ARM64, no changes to other platforms

### Verification

**Build Success:**
```bash
$ go build .
# ✅ No errors

$ go install .
# ✅ No errors
```

**Correct File Selection:**
```bash
$ go list -f '{{.GoFiles}}' ./core
[burrow.go logger.go open_out_log_darwin_arm64.go]
```

**Platform Matrix:**
| Platform | File Used | Status |
|----------|-----------|---------|
| macOS x86_64 | `unix.go` | ✅ Unchanged |
| macOS ARM64 | `darwin_arm64.go` | ✅ **Fixed** |
| Linux x86_64 | `unix.go` | ✅ Unchanged |
| Linux ARM64 | `linux_arm64.go` | ✅ Unchanged |
| Windows | `windows.go` | ✅ Unchanged |

### Testing
- [x] Builds successfully on macOS ARM64
- [x] `go install` completes without errors
- [x] Build constraints correctly select platform-specific implementation
- [x] No regression risk (mutually exclusive build constraints)

This fix resolves the compilation issue for Apple Silicon Macs while maintaining identical behavior and zero impact on other platforms.