### PR TITLE
Support hostnames ending in a dot

### DIFF
--- a/core/internal/helpers/validation.go
+++ b/core/internal/helpers/validation.go
@@ -32,7 +32,7 @@ func ValidateIP(ipaddr string) bool {
 // * The exception is IPv6 addresses, which are also permitted.
 // * An underscore is allowed to support Docker Swarm service names.
 func ValidateHostname(hostname string) bool {
-	matches, _ := regexp.MatchString(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$`, hostname)
+	matches, _ := regexp.MatchString(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*\.?$`, hostname)
 
 	if !matches {
 		// Try Docker Swarm service name

--- a/core/internal/helpers/validation_test.go
+++ b/core/internal/helpers/validation_test.go
@@ -59,6 +59,7 @@ var testHostnames = []TestSet{
 	{"invalid-docker_-service-name", false},
 	{"docker-service-may-not-end-with-underscore_", false},
 	{"_docker-service-may-not-start-with-underscore", false},
+	{"ends.in.a.dot.", true},
 }
 
 func TestValidateHostname(t *testing.T) {


### PR DESCRIPTION
Allow a trailing dot in hostnames,
e.g. example.com. is legit, just like example.com

We have burrow config specifying servers as `servers=["kafka.kafka.svc.cluster.local.:9092"]`, but currently burrow fails to start with `panic: Cluster 'XXX' has one or more improperly formatted servers (must be host:port)`