### PR TITLE
docs: update README Go version requirement to match go.mod (1.11 -> 1.24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Burrow is a monitoring companion for [Apache Kafka](http://kafka.apache.org) tha
 ## Getting Started
 ### Prerequisites
 Burrow is written in Go, so before you get started, you should [install and set up Go](https://golang.org/doc/install). As the dependencies
-are managed using Go module, the lowest version of Go supported is 1.11, though we recommend using version 1.12 for development.
+are managed using Go modules, the minimum version of Go supported is 1.24 (per `go.mod`); CI currently builds with Go 1.25.
 
 ### Build and Install
 ```


### PR DESCRIPTION
Hi, and thank you for Burrow.

One-line docs fix: the README's Getting Started section says the lowest supported Go is **1.11** (recommending 1.12), but the project actually requires far newer:

- `go.mod`: `go 1.24.0`
- CI matrix: `go-version: [1.25.x]`
- `Dockerfile`: `FROM golang:1.25.1-alpine`

Someone following the README with Go 1.12 would fail at `go build`. This PR updates the sentence to match `go.mod` (1.24 minimum, CI on 1.25).

For transparency: I used AI assistance to spot and draft this; I verified go.mod, the CI matrix, and the Dockerfile myself.
